### PR TITLE
feat: check --json フラグを追加 (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,41 @@ fn main() -> anyhow::Result<()> {
 ```bash
 cargo run -- play assets/scenarios/strange_encounter.md
 cargo run -- check assets/scenarios/strange_encounter.md
+cargo run -- check assets/scenarios/strange_encounter.md --json
 ```
 
 - `play`: CUI プレイヤーで実行
 - `check`: analyzer で静的検査
+- `check --json`: JSON 形式で検査結果を出力（CI・LLM連携用）
+
+`check --json` の出力例（問題なし）:
+
+```json
+{
+  "status": "ok",
+  "error_count": 0,
+  "warning_count": 0,
+  "issues": []
+}
+```
+
+`check --json` の出力例（エラーあり）:
+
+```json
+{
+  "status": "error",
+  "error_count": 1,
+  "warning_count": 0,
+  "issues": [
+    {
+      "level": "error",
+      "message": "ラベル 'end' へのジャンプが定義されていません"
+    }
+  ]
+}
+```
+
+エラー時は exit code 1 を返します。JSON 形式はパースエラー時でも崩れません。
 
 ---
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -9,10 +9,12 @@
 //! - 選択肢に対応するラベルが存在しない
 
 use crate::types::ast::{Ast, AstNode};
+use serde::Serialize;
 use std::collections::HashSet;
 
 /// 検査レベル
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Level {
     /// エラー：シナリオが正しく動作しない
     Error,
@@ -23,10 +25,46 @@ pub enum Level {
 }
 
 /// 検査で発見した1件の問題
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Issue {
     pub level: Level,
     pub message: String,
+}
+
+/// `--json` フラグ用の出力型
+#[derive(Debug, Serialize)]
+pub struct CheckJsonOutput {
+    /// "ok" または "error"
+    pub status: &'static str,
+    pub error_count: usize,
+    pub warning_count: usize,
+    pub issues: Vec<Issue>,
+}
+
+impl CheckJsonOutput {
+    /// パースエラーを JSON 出力に変換する
+    pub fn parse_error(message: String) -> Self {
+        Self {
+            status: "error",
+            error_count: 1,
+            warning_count: 0,
+            issues: vec![Issue {
+                level: Level::Error,
+                message,
+            }],
+        }
+    }
+}
+
+impl From<&AnalysisResult> for CheckJsonOutput {
+    fn from(result: &AnalysisResult) -> Self {
+        Self {
+            status: if result.has_errors() { "error" } else { "ok" },
+            error_count: result.error_count(),
+            warning_count: result.warning_count(),
+            issues: result.issues.clone(),
+        }
+    }
 }
 
 impl Issue {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::fs;
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
-    let usage = "使い方: tsumugai <command> <file> [--debug]\n\
+    let usage = "使い方: tsumugai <command> <file> [--json] [--debug]\n\
                  コマンド: play, check";
 
     if args.len() < 3 {
@@ -16,6 +16,7 @@ fn main() -> anyhow::Result<()> {
     let command = &args[1];
     let file_path = &args[2];
     let debug_mode = args.contains(&"--debug".to_string());
+    let json_mode = args.contains(&"--json".to_string());
 
     let markdown = fs::read_to_string(file_path)
         .map_err(|e| anyhow::anyhow!("ファイルを読み込めません '{}': {}", file_path, e))?;
@@ -25,10 +26,29 @@ fn main() -> anyhow::Result<()> {
             tsumugai::player::run(&markdown, debug_mode)?;
         }
         "check" => {
-            let ast = tsumugai::parser::parse(&markdown)?;
+            let ast = match tsumugai::parser::parse(&markdown) {
+                Ok(ast) => ast,
+                Err(e) => {
+                    if json_mode {
+                        let output =
+                            tsumugai::analyzer::CheckJsonOutput::parse_error(e.to_string());
+                        println!("{}", serde_json::to_string_pretty(&output)?);
+                        std::process::exit(1);
+                    } else {
+                        return Err(e);
+                    }
+                }
+            };
+
             let result = tsumugai::analyzer::analyze(&ast);
 
-            if result.is_clean() {
+            if json_mode {
+                let output = tsumugai::analyzer::CheckJsonOutput::from(&result);
+                println!("{}", serde_json::to_string_pretty(&output)?);
+                if result.has_errors() {
+                    std::process::exit(1);
+                }
+            } else if result.is_clean() {
                 println!("✓ 問題は見つかりませんでした。");
             } else {
                 for issue in &result.issues {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -426,6 +426,24 @@ fn check_json_parseエラーはstatus_error() {
     assert_eq!(issues[0]["level"], "error");
 }
 
+/// JSON 出力フォーマットが変わっていないことを確認する Golden テスト
+#[test]
+fn check_json_フォーマットが安定している() {
+    let md = "[SAY speaker=Alice]\nこんにちは。\n";
+    let ast = parser::parse(md).unwrap();
+    let result = tsumugai::analyzer::analyze(&ast);
+    let output = tsumugai::analyzer::CheckJsonOutput::from(&result);
+
+    let json = serde_json::to_string_pretty(&output).unwrap();
+    let expected = r#"{
+  "status": "ok",
+  "error_count": 0,
+  "warning_count": 0,
+  "issues": []
+}"#;
+    assert_eq!(json, expected, "JSON フォーマットが意図せず変わっています");
+}
+
 /// 正常なシナリオは analyzer でエラーなし
 #[test]
 fn 正常なシナリオはanalyzerでクリーン() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -352,6 +352,80 @@ fn エフェクトイベントが出力される() {
 // analyzer
 // ──────────────────────────────────────────────
 
+// ──────────────────────────────────────────────
+// check --json
+// ──────────────────────────────────────────────
+
+/// 正常シナリオの JSON 出力は status="ok"、issues=[] になる
+#[test]
+fn check_json_正常シナリオはstatus_ok() {
+    let md = r#"
+[SAY speaker=Alice]
+こんにちは。
+
+[BRANCH choice=はい label=yes, choice=いいえ label=no]
+
+[LABEL name=yes]
+[SAY speaker=Alice]
+よかった！
+
+[LABEL name=no]
+[SAY speaker=Alice]
+残念。
+"#;
+    let ast = parser::parse(md).unwrap();
+    let result = tsumugai::analyzer::analyze(&ast);
+    let output = tsumugai::analyzer::CheckJsonOutput::from(&result);
+
+    let json = serde_json::to_string(&output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(v["status"], "ok");
+    assert_eq!(v["error_count"], 0);
+    assert!(v["issues"].is_array());
+}
+
+/// 警告があるとき status="ok" のまま warning_count が反映される
+#[test]
+fn check_json_警告ありはstatus_ok_with_warnings() {
+    // 選択肢1つの BRANCH → warning
+    let md = r#"
+[BRANCH choice=進む label=go]
+
+[LABEL name=go]
+[SAY speaker=A]
+進む
+"#;
+    let ast = parser::parse(md).unwrap();
+    let result = tsumugai::analyzer::analyze(&ast);
+    let output = tsumugai::analyzer::CheckJsonOutput::from(&result);
+
+    let json = serde_json::to_string(&output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(v["status"], "ok");
+    assert!(v["warning_count"].as_u64().unwrap() > 0);
+    let issues = v["issues"].as_array().unwrap();
+    assert!(issues.iter().any(|i| i["level"] == "warning"));
+}
+
+/// パースエラー時の JSON 出力が valid JSON で status="error" になる
+#[test]
+fn check_json_parseエラーはstatus_error() {
+    let output = tsumugai::analyzer::CheckJsonOutput::parse_error(
+        "Undefined label 'missing' referenced".to_string(),
+    );
+
+    let json = serde_json::to_string(&output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(v["status"], "error");
+    assert_eq!(v["error_count"], 1);
+    let issues = v["issues"].as_array().unwrap();
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0]["level"], "error");
+}
+
 /// 正常なシナリオは analyzer でエラーなし
 #[test]
 fn 正常なシナリオはanalyzerでクリーン() {


### PR DESCRIPTION
## 概要

issue #37 の実装。`tsumugai check <file> --json` でDiagnosticをJSON形式で出力できるようにする。

Closes #37

## 変更内容

- `src/analyzer/mod.rs`: `Level`・`Issue` に `Serialize` を追加。`CheckJsonOutput` 型を追加
- `src/main.rs`: `--json` フラグ対応。パースエラー時もJSON形式を維持
- `tests/integration_test.rs`: JSON出力テスト3件追加
- `README.md`: `check --json` の使用例を追加

## 動作確認

**正常シナリオ:**
```
$ tsumugai check scenario.md --json
{
  "status": "ok",
  "error_count": 0,
  "warning_count": 0,
  "issues": []
}
```

**エラーあり:**
```json
{
  "status": "error",
  "error_count": 1,
  "warning_count": 0,
  "issues": [
    {
      "level": "error",
      "message": "..."
    }
  ]
}
```

- エラー時は exit code 1
- パースエラー時もJSONが崩れない（CI・LLM連携で安全に使える）

## Test plan

- [ ] `cargo fmt --check` 通過
- [ ] `cargo clippy --all-targets -- -D warnings` 通過
- [ ] `cargo test` 通過（新規3件含む全テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `check --json` オプションを追加しました。検証結果をCI/LLM連携に適したJSONで出力します（エラー時もJSON出力し終了コード1を返します）。
* **ドキュメント**
  * CLI使用例とJSON出力の成功／エラー例をREADMEに追記しました。
* **テスト**
  * JSON出力の正常系・警告・パースエラーを検証する統合テストと出力のGolden比較テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/46)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->