### PR TITLE
feat: ENDINGコマンドを追加してシナリオ終端を明示できるようにする

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -210,6 +210,11 @@ impl MarkdownParser {
                 let layer = self.require_param(&params, "layer", command_name)?;
                 Ok(AstNode::ClearLayer { layer })
             }
+            "ENDING" | "END" => {
+                let id = self.require_param(&params, "id", command_name)?;
+                let name = params.get("name").and_then(|v| v.first()).cloned();
+                Ok(AstNode::Ending { id, name })
+            }
             _ => anyhow::bail!(
                 "Unknown command '{}' at line {}",
                 command_name,

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -116,6 +116,12 @@ pub fn run(markdown: &str, debug_mode: bool) -> anyhow::Result<()> {
                 }
             }
 
+            Some(WaitingType::Ended { ref id, ref name }) => {
+                history.pop();
+                print_scenario_ending(id, name);
+                break;
+            }
+
             Some(WaitingType::Choice(ref options)) => {
                 // 選択肢待ち
                 print_choices(options);
@@ -266,6 +272,13 @@ fn print_choices(options: &[crate::runtime::ir::ChoiceOption]) {
 fn print_ending() {
     println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     println!("          THE END");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+}
+
+fn print_scenario_ending(id: &str, name: &str) {
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("  エンディング: {}", name);
+    println!("  (id: {})", id);
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 }
 

--- a/src/player/view_state.rs
+++ b/src/player/view_state.rs
@@ -87,8 +87,8 @@ impl ViewState {
                         .push(format!("カスタム: {} {:?}", tag, params));
                 }
 
-                // Say は ViewState には影響しない（player 側で表示）
-                Event::Say { .. } => {}
+                // Say / Ending は ViewState には影響しない（player 側で表示）
+                Event::Say { .. } | Event::Ending { .. } => {}
             }
         }
 

--- a/src/runtime/ir.rs
+++ b/src/runtime/ir.rs
@@ -45,6 +45,9 @@ pub enum Op {
         value: String,
     },
 
+    /// シナリオ終了（エンディング到達後に実行を停止する）
+    Halt,
+
     // ──────────────────────────────
     // イベント生成
     // runtime はこれを Output に積むだけで内容を解釈しない
@@ -82,6 +85,9 @@ pub enum Event {
 
     /// 時間待ち（実際に sleep するかはプレイヤー側の判断）
     Wait { duration: f32 },
+
+    /// エンディング到達
+    Ending { id: String, name: String },
 
     /// 拡張コマンド
     Custom { tag: String, params: Vec<String> },

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -53,6 +53,8 @@ pub enum WaitingType {
     Advance,
     /// 選択肢待ち（表示に必要な選択肢一覧を含む）
     Choice(Vec<ChoiceOption>),
+    /// エンディング到達（シナリオ終了）
+    Ended { id: String, name: String },
 }
 
 impl Output {
@@ -239,6 +241,15 @@ impl Compiler {
                 });
             }
 
+            AstNode::Ending { id, name } => {
+                let display_name = name.clone().unwrap_or_else(|| id.clone());
+                self.ops.push(PreOp::Resolved(Op::Emit(Event::Ending {
+                    id: id.clone(),
+                    name: display_name,
+                })));
+                self.ops.push(PreOp::Resolved(Op::Halt));
+            }
+
             AstNode::WhenBlock { condition, body } => {
                 // 条件が偽のときボディをスキップするジャンプを挿入
                 // ops.len() ではなくグローバルカウンターを使って衝突を防ぐ
@@ -382,6 +393,19 @@ pub fn step(mut state: State, program: &Program, input: Option<Input>) -> (State
                 } else {
                     state.pc += 1;
                 }
+            }
+
+            Op::Halt => {
+                let ended = output.events.iter().find_map(|e| {
+                    if let Event::Ending { id, name } = e {
+                        Some((id.clone(), name.clone()))
+                    } else {
+                        None
+                    }
+                });
+                let (id, name) = ended.unwrap_or_default();
+                output.waiting_for = Some(WaitingType::Ended { id, name });
+                break;
             }
 
             Op::Set { key, value } => {

--- a/src/types/ast.rs
+++ b/src/types/ast.rs
@@ -93,6 +93,8 @@ pub enum AstNode {
     Scene { name: String },
     /// 条件付き実行ブロック
     WhenBlock { condition: Expr, body: Vec<AstNode> },
+    /// エンディング到達（シナリオ終端を明示する）
+    Ending { id: String, name: Option<String> },
 }
 
 /// 選択肢の1項目

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -445,6 +445,50 @@ fn check_json_フォーマットが安定している() {
 }
 
 /// 正常なシナリオは analyzer でエラーなし
+/// ENDING コマンドでシナリオが終了しエンディングIDが出力に含まれる
+#[test]
+fn endingコマンドでシナリオが終了する() {
+    let md = r#"
+[SAY speaker=Alice]
+これが最後の台詞。
+
+[ENDING id=good name=グッドエンド]
+"#;
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    // 1回目: Say + AwaitAdvance
+    let state = State::new();
+    let (state, output) = runtime::step(state, &program, None);
+    assert!(matches!(output.waiting_for, Some(WaitingType::Advance)));
+
+    // Enter で進む → Ending イベントが発生し、Ended で停止
+    let (_state, output) = runtime::step(state, &program, Some(Input::Advance));
+
+    assert!(output.events.iter().any(|e| matches!(
+        e,
+        Event::Ending { id, name } if id == "good" && name == "グッドエンド"
+    )));
+    assert!(matches!(
+        output.waiting_for,
+        Some(WaitingType::Ended { ref id, ref name }) if id == "good" && name == "グッドエンド"
+    ));
+}
+
+/// END コマンド（ENDINGの別名）も動作する
+#[test]
+fn endコマンドがendingと同様に動作する() {
+    let md = "[END id=bad]\n";
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    let state = State::new();
+    let (_state, output) = runtime::step(state, &program, None);
+
+    assert!(output.events.iter().any(|e| matches!(e, Event::Ending { id, .. } if id == "bad")));
+    assert!(matches!(output.waiting_for, Some(WaitingType::Ended { .. })));
+}
+
 #[test]
 fn 正常なシナリオはanalyzerでクリーン() {
     let md = r#"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -485,8 +485,16 @@ fn endコマンドがendingと同様に動作する() {
     let state = State::new();
     let (_state, output) = runtime::step(state, &program, None);
 
-    assert!(output.events.iter().any(|e| matches!(e, Event::Ending { id, .. } if id == "bad")));
-    assert!(matches!(output.waiting_for, Some(WaitingType::Ended { .. })));
+    assert!(
+        output
+            .events
+            .iter()
+            .any(|e| matches!(e, Event::Ending { id, .. } if id == "bad"))
+    );
+    assert!(matches!(
+        output.waiting_for,
+        Some(WaitingType::Ended { .. })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

issue #33 の実装。`[ENDING id=good name=グッドエンド]` または `[END id=bad]` で
シナリオの終端を明示するコマンドを追加しました。

## 変更内容

### 新しいDSL構文

```markdown
[ENDING id=good name=グッドエンド]
[END id=bad]
```

### 入力例

```markdown
[SAY speaker=Alice]
これが最後の台詞。

[ENDING id=good name=グッドエンド]
```

### runtime出力の変化

```
events: [
  Ending { id: "good", name: "グッドエンド" }
]
waiting_for: Ended { id: "good", name: "グッドエンド" }
```

`WaitingType::Ended` がセットされることでシナリオ終了をプレイヤー側が検知できます。

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/types/ast.rs` | `AstNode::Ending { id, name: Option<String> }` 追加 |
| `src/runtime/ir.rs` | `Event::Ending { id, name }` と `Op::Halt` 追加 |
| `src/runtime/mod.rs` | `WaitingType::Ended { id, name }` 追加、コンパイル・実行対応 |
| `src/player/mod.rs` | エンディング到達時の表示を追加 |
| `src/player/view_state.rs` | `Event::Ending` を ViewState の無視対象に追加 |
| `tests/integration_test.rs` | 統合テスト 2 件追加 |

## テスト結果

```
cargo fmt --check      ✅
cargo clippy -D warnings ✅ (コード警告ゼロ)
cargo test             ✅ 25/25 passed
```

## 関連

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シナリオ終了コマンド（ENDING / END）を追加。指定したIDと任意の名前でシナリオを終了し、終了時に対応する終了表示（バナー）が表示され、プレイが終了状態になります。

* **テスト**
  * 終了コマンドと終了遷移を検証する統合テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/47)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->