### PR TITLE
fix: 条件付き選択肢（BRANCH if=）を runtime で評価するよう修正 (#32)

### DIFF
--- a/src/runtime/ir.rs
+++ b/src/runtime/ir.rs
@@ -102,6 +102,8 @@ pub struct ChoiceOption {
     pub label: String,
     /// ジャンプ先の IR インデックス（ラベル解決済み）
     pub target_pc: usize,
+    /// 表示条件（None なら常に表示）
+    pub condition: Option<Expr>,
 }
 
 /// 変数演算の種類

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -99,6 +99,7 @@ struct PreChoice {
     id: String,
     label: String,
     target_label: String,
+    condition: Option<String>,
 }
 
 struct Compiler {
@@ -234,6 +235,7 @@ impl Compiler {
                         id: format!("{}_branch_{}_choice_{}", scene, branch_idx, i),
                         label: c.label.clone(),
                         target_label: c.target.clone(),
+                        condition: c.condition.clone(),
                     })
                     .collect();
                 self.ops.push(PreOp::AwaitChoice {
@@ -309,6 +311,7 @@ impl Compiler {
                                 id: c.id,
                                 label: c.label,
                                 target_pc,
+                                condition: c.condition.map(Expr::Var),
                             }
                         })
                         .collect();
@@ -357,7 +360,12 @@ pub fn step(mut state: State, program: &Program, input: Option<Input>) -> (State
             }
             Input::SelectChoice(id) => {
                 if let Some(Op::AwaitChoice { options }) = program.get(state.pc)
-                    && let Some(opt) = options.iter().find(|o| &o.id == id)
+                    && let Some(opt) = options.iter().find(|o| {
+                        &o.id == id
+                            && o.condition
+                                .as_ref()
+                                .is_none_or(|cond| eval_expr(cond, &state))
+                    })
                 {
                     state.pc = opt.target_pc;
                 }
@@ -379,7 +387,16 @@ pub fn step(mut state: State, program: &Program, input: Option<Input>) -> (State
             }
 
             Op::AwaitChoice { options } => {
-                output.waiting_for = Some(WaitingType::Choice(options.clone()));
+                let visible: Vec<ChoiceOption> = options
+                    .iter()
+                    .filter(|o| {
+                        o.condition
+                            .as_ref()
+                            .is_none_or(|cond| eval_expr(cond, &state))
+                    })
+                    .cloned()
+                    .collect();
+                output.waiting_for = Some(WaitingType::Choice(visible));
                 break;
             }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -517,3 +517,116 @@ fn 正常なシナリオはanalyzerでクリーン() {
     let result = tsumugai::analyzer::analyze(&ast);
     assert!(!result.has_errors());
 }
+
+// ──────────────────────────────────────────────
+// 条件付き選択肢
+// ──────────────────────────────────────────────
+
+/// 条件が真の選択肢は表示され、偽の選択肢は表示されない
+#[test]
+fn 条件付き選択肢_条件が偽の選択肢は非表示() {
+    // has_sword が設定されていない状態 → if=has_sword の選択肢は表示されない
+    // パーサーは if= を choice インデックス順に割り当てるので
+    // 最初の choice に条件を付ける形式: choice=剣で戦う if=has_sword label=fight
+    let md = r#"
+[BRANCH choice=剣で戦う if=has_sword label=fight, choice=逃げる label=run]
+
+[LABEL name=fight]
+[SAY speaker=主人公]
+戦った！
+
+[LABEL name=run]
+[SAY speaker=主人公]
+逃げた！
+"#;
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    let state = State::new(); // has_sword は未設定
+    let (_, output) = runtime::step(state, &program, None);
+
+    let opts = if let Some(WaitingType::Choice(opts)) = output.waiting_for {
+        opts
+    } else {
+        panic!("選択肢が返されなかった");
+    };
+
+    assert_eq!(opts.len(), 1, "条件が偽の選択肢は除外されるはず");
+    assert_eq!(opts[0].label, "逃げる");
+}
+
+/// 条件が真になると選択肢が表示される
+#[test]
+fn 条件付き選択肢_条件が真の選択肢は表示される() {
+    let md = r#"
+[SET name=has_sword value=true]
+[BRANCH choice=剣で戦う if=has_sword label=fight, choice=逃げる label=run]
+
+[LABEL name=fight]
+[SAY speaker=主人公]
+戦った！
+
+[LABEL name=run]
+[SAY speaker=主人公]
+逃げた！
+"#;
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    let state = State::new();
+    let (_, output) = runtime::step(state, &program, None);
+
+    let opts = if let Some(WaitingType::Choice(opts)) = output.waiting_for {
+        opts
+    } else {
+        panic!("選択肢が返されなかった");
+    };
+
+    assert_eq!(opts.len(), 2, "条件が真なので両方の選択肢が表示されるはず");
+}
+
+/// 条件が偽の選択肢 ID を直接送っても無視される（バイパス防止）
+#[test]
+fn 条件付き選択肢_条件偽の選択肢はバイパスできない() {
+    let md = r#"
+[BRANCH choice=剣で戦う if=has_sword label=fight, choice=逃げる label=run]
+
+[LABEL name=fight]
+[SAY speaker=主人公]
+戦った！
+
+[LABEL name=run]
+[SAY speaker=主人公]
+逃げた！
+"#;
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    // has_sword 未設定で fight の選択肢 ID を直接送る
+    let state = State::new();
+    let (state, output) = runtime::step(state, &program, None);
+    let fight_id = if let Some(WaitingType::Choice(_opts)) = &output.waiting_for {
+        // 表示されていない fight の ID を IR から直接取得する
+        use tsumugai::runtime::ir::Op;
+        if let Some(Op::AwaitChoice { options }) = program.get(state.pc) {
+            options
+                .iter()
+                .find(|o| o.label == "剣で戦う")
+                .unwrap()
+                .id
+                .clone()
+        } else {
+            panic!("AwaitChoice 命令がない");
+        }
+    } else {
+        panic!("選択肢待ちでない");
+    };
+
+    // 条件が偽の ID を送ってもジャンプしない（PC はそのまま）
+    let pc_before = state.pc;
+    let (state_after, _) = runtime::step(state, &program, Some(Input::SelectChoice(fight_id)));
+    assert_eq!(
+        state_after.pc, pc_before,
+        "条件が偽の選択肢はバイパスできないはず"
+    );
+}


### PR DESCRIPTION
## 概要

`BRANCH` コマンドの `if=` 条件が runtime で完全に無視されていたバグを修正します。

closes #32

## 変更内容

### 何が問題だったか

`Choice.condition` はパース済みだったが、`ChoiceOption`（IR）にフィールドがなく、コンパイル・実行時に条件が評価されていなかった。

### どう直したか

| ファイル | 変更内容 |
|---|---|
| `src/runtime/ir.rs` | `ChoiceOption` に `condition: Option<Expr>` を追加 |
| `src/runtime/mod.rs` | コンパイル時に `Choice.condition` を `Expr::Var` に変換して `ChoiceOption` に伝搬。`step()` の `AwaitChoice` 処理で条件が偽の選択肢をフィルタリング。`SelectChoice` 入力処理でも条件を再評価してバイパスを防止 |
| `tests/integration_test.rs` | 条件付き選択肢の統合テスト3件を追加 |

## 動作確認（Markdown 入力と出力の変化）

### 条件が偽のとき（変数未設定）

```markdown
[BRANCH choice=剣で戦う if=has_sword label=fight, choice=逃げる label=run]
```

修正前: `WaitingType::Choice([剣で戦う, 逃げる])` — 条件が無視されて両方表示  
修正後: `WaitingType::Choice([逃げる])` — 条件が偽の選択肢は表示されない

### 条件が真のとき（変数セット済み）

```markdown
[SET name=has_sword value=true]
[BRANCH choice=剣で戦う if=has_sword label=fight, choice=逃げる label=run]
```

修正後: `WaitingType::Choice([剣で戦う, 逃げる])` — 両方表示される

### バイパス防止

条件が偽の選択肢 ID を `SelectChoice` で直接送っても PC が動かない（ジャンプしない）。

## 検証

```
cargo fmt --check  ✅
cargo clippy --all-targets -- -D warnings  ✅
cargo test  ✅ (23 unit + 19 integration + 1 doctest)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ブランチの選択肢に条件付き表示機能を追加。指定された条件が満たされない場合、その選択肢は表示されなくなります。
  
* **Tests**
  * 条件付き選択肢の表示・非表示動作および条件バイパス防止の統合テストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/48)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->