### PR TITLE
feat: Golden JSONテストを導入する

### DIFF
--- a/tests/fixtures/branch.md
+++ b/tests/fixtures/branch.md
@@ -8,7 +8,11 @@ Choose your path.
 [SAY speaker=Guide]
 You went left.
 
+[JUMP label=end]
+
 [LABEL name=go_right]
 
 [SAY speaker=Guide]
 You went right.
+
+[LABEL name=end]

--- a/tests/golden/branch.events.json
+++ b/tests/golden/branch.events.json
@@ -1,0 +1,108 @@
+{
+  "left": [
+    {
+      "events": [
+        {
+          "Say": {
+            "speaker": "Guide",
+            "text": "Choose your path."
+          }
+        }
+      ],
+      "input": null,
+      "step": 0,
+      "waiting_for": "Advance"
+    },
+    {
+      "events": [],
+      "input": "Advance",
+      "step": 1,
+      "waiting_for": {
+        "Choice": [
+          {
+            "id": "root_branch_0_choice_0",
+            "label": "Left"
+          },
+          {
+            "id": "root_branch_0_choice_1",
+            "label": "Right"
+          }
+        ]
+      }
+    },
+    {
+      "events": [
+        {
+          "Say": {
+            "speaker": "Guide",
+            "text": "You went left."
+          }
+        }
+      ],
+      "input": {
+        "SelectChoice": "root_branch_0_choice_0"
+      },
+      "step": 2,
+      "waiting_for": "Advance"
+    },
+    {
+      "events": [],
+      "input": "Advance",
+      "step": 3,
+      "waiting_for": null
+    }
+  ],
+  "right": [
+    {
+      "events": [
+        {
+          "Say": {
+            "speaker": "Guide",
+            "text": "Choose your path."
+          }
+        }
+      ],
+      "input": null,
+      "step": 0,
+      "waiting_for": "Advance"
+    },
+    {
+      "events": [],
+      "input": "Advance",
+      "step": 1,
+      "waiting_for": {
+        "Choice": [
+          {
+            "id": "root_branch_0_choice_0",
+            "label": "Left"
+          },
+          {
+            "id": "root_branch_0_choice_1",
+            "label": "Right"
+          }
+        ]
+      }
+    },
+    {
+      "events": [
+        {
+          "Say": {
+            "speaker": "Guide",
+            "text": "You went right."
+          }
+        }
+      ],
+      "input": {
+        "SelectChoice": "root_branch_0_choice_1"
+      },
+      "step": 2,
+      "waiting_for": "Advance"
+    },
+    {
+      "events": [],
+      "input": "Advance",
+      "step": 3,
+      "waiting_for": null
+    }
+  ]
+}

--- a/tests/golden/simple.events.json
+++ b/tests/golden/simple.events.json
@@ -1,0 +1,39 @@
+[
+  {
+    "events": [
+      {
+        "Say": {
+          "speaker": "Hero",
+          "text": "Hello, world!"
+        }
+      }
+    ],
+    "input": null,
+    "step": 0,
+    "waiting_for": "Advance"
+  },
+  {
+    "events": [
+      {
+        "Wait": {
+          "duration": 1.0
+        }
+      },
+      {
+        "Say": {
+          "speaker": "Hero",
+          "text": "Goodbye!"
+        }
+      }
+    ],
+    "input": "Advance",
+    "step": 1,
+    "waiting_for": "Advance"
+  },
+  {
+    "events": [],
+    "input": "Advance",
+    "step": 2,
+    "waiting_for": null
+  }
+]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -71,9 +71,10 @@ fn compare_or_update_golden(path: &str, actual: &str) {
             actual, expected,
             "Golden file mismatch: {path}\nRun `UPDATE_GOLDEN=1 cargo test` to update."
         ),
-        Err(_) => panic!(
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => panic!(
             "Golden file not found: {path}\nRun `UPDATE_GOLDEN=1 cargo test` to create it.\n\nActual output:\n{actual}"
         ),
+        Err(e) => panic!("Failed to read golden file {path}: {e}"),
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,11 +2,80 @@
 //!
 //! parser → runtime の連携を end-to-end でテストする。
 
+use serde_json::{Value, json};
 use tsumugai::{
     parser,
-    runtime::{self, Input, WaitingType, ir::Event},
+    runtime::{self, Input, WaitingType, ir::Event, ir::Program},
     types::state::State,
 };
+
+// ──────────────────────────────────────────────
+// ゴールデンテスト用ヘルパー
+// ──────────────────────────────────────────────
+
+fn input_to_json(input: Option<&Input>) -> Value {
+    match input {
+        None => Value::Null,
+        Some(Input::Advance) => json!("Advance"),
+        Some(Input::SelectChoice(id)) => json!({ "SelectChoice": id }),
+    }
+}
+
+fn waiting_for_to_json(wf: Option<&WaitingType>) -> Value {
+    match wf {
+        None => Value::Null,
+        Some(WaitingType::Advance) => json!("Advance"),
+        Some(WaitingType::Choice(opts)) => {
+            let choices: Vec<Value> = opts
+                .iter()
+                .map(|o| json!({ "id": o.id, "label": o.label }))
+                .collect();
+            json!({ "Choice": choices })
+        }
+        Some(WaitingType::Ended { id, name }) => json!({ "Ended": { "id": id, "name": name } }),
+    }
+}
+
+fn play_scenario(program: &Program, inputs: &[Option<Input>]) -> Vec<Value> {
+    let mut state = State::new();
+    let mut steps = vec![];
+    for (idx, input) in inputs.iter().enumerate() {
+        let (next_state, output) = runtime::step(state, program, input.clone());
+        state = next_state;
+        let events: Vec<Value> = output
+            .events
+            .iter()
+            .map(|e| serde_json::to_value(e).unwrap())
+            .collect();
+        steps.push(json!({
+            "step": idx,
+            "input": input_to_json(input.as_ref()),
+            "events": events,
+            "waiting_for": waiting_for_to_json(output.waiting_for.as_ref()),
+        }));
+    }
+    steps
+}
+
+fn compare_or_update_golden(path: &str, actual: &str) {
+    if std::env::var("UPDATE_GOLDEN").is_ok() {
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, actual).unwrap();
+        eprintln!("Updated golden file: {path}");
+        return;
+    }
+    match std::fs::read_to_string(path) {
+        Ok(expected) => assert_eq!(
+            actual, expected,
+            "Golden file mismatch: {path}\nRun `UPDATE_GOLDEN=1 cargo test` to update."
+        ),
+        Err(_) => panic!(
+            "Golden file not found: {path}\nRun `UPDATE_GOLDEN=1 cargo test` to create it.\n\nActual output:\n{actual}"
+        ),
+    }
+}
 
 // ──────────────────────────────────────────────
 // 基本動作
@@ -629,4 +698,49 @@ fn 条件付き選択肢_条件偽の選択肢はバイパスできない() {
         state_after.pc, pc_before,
         "条件が偽の選択肢はバイパスできないはず"
     );
+}
+
+// ──────────────────────────────────────────────
+// ゴールデン JSON テスト
+// ──────────────────────────────────────────────
+
+/// simple.md の全ステップ出力が変わっていないことを確認する
+#[test]
+fn golden_simple_events() {
+    let md = include_str!("fixtures/simple.md");
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    let inputs: Vec<Option<Input>> = vec![None, Some(Input::Advance), Some(Input::Advance)];
+    let steps = play_scenario(&program, &inputs);
+    let actual = serde_json::to_string_pretty(&steps).unwrap();
+    compare_or_update_golden("tests/golden/simple.events.json", &actual);
+}
+
+/// branch.md の左右両分岐のステップ出力が変わっていないことを確認する
+#[test]
+fn golden_branch_events() {
+    let md = include_str!("fixtures/branch.md");
+    let ast = parser::parse(md).unwrap();
+    let program = runtime::compile(&ast);
+
+    let left_inputs: Vec<Option<Input>> = vec![
+        None,
+        Some(Input::Advance),
+        Some(Input::SelectChoice("root_branch_0_choice_0".to_string())),
+        Some(Input::Advance),
+    ];
+    let right_inputs: Vec<Option<Input>> = vec![
+        None,
+        Some(Input::Advance),
+        Some(Input::SelectChoice("root_branch_0_choice_1".to_string())),
+        Some(Input::Advance),
+    ];
+
+    let result = json!({
+        "left": play_scenario(&program, &left_inputs),
+        "right": play_scenario(&program, &right_inputs),
+    });
+    let actual = serde_json::to_string_pretty(&result).unwrap();
+    compare_or_update_golden("tests/golden/branch.events.json", &actual);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -58,7 +58,7 @@ fn play_scenario(program: &Program, inputs: &[Option<Input>]) -> Vec<Value> {
 }
 
 fn compare_or_update_golden(path: &str, actual: &str) {
-    if std::env::var("UPDATE_GOLDEN").is_ok() {
+    if std::env::var("UPDATE_GOLDEN").as_deref() == Ok("1") {
         if let Some(parent) = std::path::Path::new(path).parent() {
             std::fs::create_dir_all(parent).unwrap();
         }


### PR DESCRIPTION
## 概要

issue #39 の実装です。

Rust コードを読まなくても挙動の差分をレビューできるよう、代表シナリオに対する期待出力を JSON で保存するゴールデンテストを導入しました。

## 変更内容

### 新規ファイル
- `tests/golden/simple.events.json` — `simple.md` の全ステップ出力（3ステップ分のイベント列）
- `tests/golden/branch.events.json` — `branch.md` の左右両分岐のステップ出力

### 変更ファイル
- `tests/integration_test.rs` — ゴールデンテスト用ヘルパーと2つのテスト関数を追加
  - `play_scenario` — 入力列を渡してステップ実行し JSON を返す
  - `compare_or_update_golden` — ゴールデンファイルと比較（`UPDATE_GOLDEN=1` で再生成）
  - `golden_simple_events` テスト
  - `golden_branch_events` テスト
- `tests/fixtures/branch.md` — `[JUMP label=end]` を追加して左右分岐の fall-through を解消

## JSON 出力例（simple.events.json 抜粋）

```json
[
  {
    "step": 0,
    "input": null,
    "events": [{"Say": {"speaker": "Hero", "text": "Hello, world!"}}],
    "waiting_for": "Advance"
  },
  ...
]
```

各ステップに `input` / `events` / `waiting_for` が記録されるため、挙動が変わったときに差分が一目でわかります。

## ゴールデンファイルの更新方法

```bash
UPDATE_GOLDEN=1 cargo test
```

## テスト結果

```
cargo fmt --check  ✅
cargo clippy -- -D warnings  ✅
cargo test  ✅  (21 passed)
```

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * シンプルなフローと左右の分岐パターンを検証するゴールデンテストを追加しました。
  * 実行ごとのイベントシーケンスをJSONで記録・比較するテストヘルパーを実装しました。
  * ゴールデンを自動で更新できる仕組みを導入し、差分管理を容易にしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/50)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->