### PR TITLE
feat: analyzer::Issue に rule_id / span / suggestion を追加して構造化 Diagnostic を実装

### DIFF
--- a/docs/DIAGNOSTIC.md
+++ b/docs/DIAGNOSTIC.md
@@ -15,11 +15,12 @@
 
 ```rust
 pub struct Issue {
-    pub rule_id: &'static str,   // ルール種別（機械的識別用）
-    pub level: Level,            // Error / Warning / Info
-    pub message: String,         // 人間向けの説明
-    pub span: Option<Span>,      // ソース上の位置（将来実装）
-    pub suggestion: Option<String>, // 修正提案（任意）
+    pub rule_id: &'static str,       // ルール種別（機械的識別用）
+    pub level: Level,                // Error / Warning / Info
+    pub message: String,             // 人間向けの説明
+    pub span: Option<Span>,          // 主要な位置（将来実装）
+    pub related_spans: Vec<Span>,    // 関連位置（将来実装）
+    pub suggestion: Option<String>,  // 修正提案（任意）
 }
 
 pub struct Span {
@@ -68,6 +69,7 @@ pub struct Span {
       "level": "error",
       "message": "未定義ラベル 'good_end' へのジャンプが存在します",
       "span": null,
+      "related_spans": [],
       "suggestion": "'[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください"
     }
   ]
@@ -78,7 +80,7 @@ pub struct Span {
 
 ## 5. CLIでの人間向け表示
 
-```
+```text
 [エラー][undefined_label] 未定義ラベル 'good_end' へのジャンプが存在します
   提案: '[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください
 ```
@@ -98,4 +100,4 @@ pub struct Span {
 - `rule_id` で LLM・CI がフィルタ・集計できるようにする
 - `message` は日本語で人間が読める説明にする
 - `suggestion` は省略可能だが、エラー系には極力付ける
-- `span` は将来のために `Option` として予約し、現時点では `null`
+- `span` / `related_spans` は将来のために型として予約し、現時点ではそれぞれ `null` / `[]`

--- a/docs/DIAGNOSTIC.md
+++ b/docs/DIAGNOSTIC.md
@@ -1,0 +1,101 @@
+# Diagnostic — 構造化エラー・警告の設計方針
+
+この文書は、`tsumugai` の静的検査結果（`analyzer::Issue`）の型設計と JSON 出力形式を定義します。
+
+---
+
+## 1. 位置づけ
+
+`analyzer::Issue` が Diagnostic の役割を担います。  
+`tsumugai check` の結果として返され、LLM・CI・人間の三者が共通して扱える形式を目指します。
+
+---
+
+## 2. 型定義
+
+```rust
+pub struct Issue {
+    pub rule_id: &'static str,   // ルール種別（機械的識別用）
+    pub level: Level,            // Error / Warning / Info
+    pub message: String,         // 人間向けの説明
+    pub span: Option<Span>,      // ソース上の位置（将来実装）
+    pub suggestion: Option<String>, // 修正提案（任意）
+}
+
+pub struct Span {
+    pub line: usize,    // 1-origin
+    pub column: usize,  // 1-origin
+}
+```
+
+---
+
+## 3. rule_id 一覧
+
+| rule_id | level | 内容 |
+|:---|:---|:---|
+| `undefined_label` | Error | 未定義ラベルへのジャンプ・選択肢参照 |
+| `unreferenced_label` | Info | どこからも参照されていないラベル |
+| `empty_branch` | Error | 選択肢が0個の BRANCH |
+| `single_choice_branch` | Warning | 選択肢が1個しかない BRANCH |
+| `parse_error` | Error | パース失敗（`CheckJsonOutput::parse_error` が使用） |
+
+---
+
+## 4. JSON 出力例
+
+### 正常
+
+```json
+{
+  "status": "ok",
+  "error_count": 0,
+  "warning_count": 0,
+  "issues": []
+}
+```
+
+### エラーあり
+
+```json
+{
+  "status": "error",
+  "error_count": 1,
+  "warning_count": 0,
+  "issues": [
+    {
+      "rule_id": "undefined_label",
+      "level": "error",
+      "message": "未定義ラベル 'good_end' へのジャンプが存在します",
+      "span": null,
+      "suggestion": "'[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください"
+    }
+  ]
+}
+```
+
+---
+
+## 5. CLIでの人間向け表示
+
+```
+[エラー][undefined_label] 未定義ラベル 'good_end' へのジャンプが存在します
+  提案: '[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください
+```
+
+---
+
+## 6. span について
+
+現在 `span` は常に `null` です。  
+パーサーが行番号を AstNode に付与するようになった段階で埋める予定です。  
+`Span` 型はすでに定義済みのため、API の形式は変わりません。
+
+---
+
+## 7. 設計原則
+
+- `rule_id` で LLM・CI がフィルタ・集計できるようにする
+- `message` は日本語で人間が読める説明にする
+- `suggestion` は省略可能だが、エラー系には極力付ける
+- `span` は将来のために `Option` として予約し、現時点では `null`

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -24,11 +24,25 @@ pub enum Level {
     Info,
 }
 
-/// 検査で発見した1件の問題
+/// ソースコード上の位置（行・列は 1-origin）
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Span {
+    pub line: usize,
+    pub column: usize,
+}
+
+/// 検査で発見した1件の問題（Diagnostic）
+///
+/// `rule_id` でルール種別を機械的に識別できる。
+/// `span` は将来的にパーサーが行番号を付与したときに利用する（現在は None）。
+/// `suggestion` があれば修正方法をユーザーに提示する。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Issue {
+    pub rule_id: &'static str,
     pub level: Level,
     pub message: String,
+    pub span: Option<Span>,
+    pub suggestion: Option<String>,
 }
 
 /// `--json` フラグ用の出力型
@@ -49,8 +63,11 @@ impl CheckJsonOutput {
             error_count: 1,
             warning_count: 0,
             issues: vec![Issue {
+                rule_id: "parse_error",
                 level: Level::Error,
                 message,
+                span: None,
+                suggestion: None,
             }],
         }
     }
@@ -68,25 +85,39 @@ impl From<&AnalysisResult> for CheckJsonOutput {
 }
 
 impl Issue {
-    fn error(msg: impl Into<String>) -> Self {
+    fn error(rule_id: &'static str, msg: impl Into<String>) -> Self {
         Self {
+            rule_id,
             level: Level::Error,
             message: msg.into(),
+            span: None,
+            suggestion: None,
         }
     }
 
-    fn warning(msg: impl Into<String>) -> Self {
+    fn warning(rule_id: &'static str, msg: impl Into<String>) -> Self {
         Self {
+            rule_id,
             level: Level::Warning,
             message: msg.into(),
+            span: None,
+            suggestion: None,
         }
     }
 
-    fn info(msg: impl Into<String>) -> Self {
+    fn info(rule_id: &'static str, msg: impl Into<String>) -> Self {
         Self {
+            rule_id,
             level: Level::Info,
             message: msg.into(),
+            span: None,
+            suggestion: None,
         }
+    }
+
+    fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
+        self.suggestion = Some(suggestion.into());
+        self
     }
 }
 
@@ -141,24 +172,45 @@ fn check_label_references(ast: &Ast, defined: &HashSet<&str>, result: &mut Analy
     for node in &ast.nodes {
         match node {
             AstNode::Jump { label } if !defined.contains(label.as_str()) => {
-                result.issues.push(Issue::error(format!(
-                    "未定義ラベル '{}' へのジャンプが存在します",
-                    label
-                )));
+                result.issues.push(
+                    Issue::error(
+                        "undefined_label",
+                        format!("未定義ラベル '{}' へのジャンプが存在します", label),
+                    )
+                    .with_suggestion(format!(
+                        "'[LABEL name={}]' を追加するか、ジャンプ先を修正してください",
+                        label
+                    )),
+                );
             }
             AstNode::JumpIf { label, .. } if !defined.contains(label.as_str()) => {
-                result.issues.push(Issue::error(format!(
-                    "未定義ラベル '{}' への条件ジャンプが存在します",
-                    label
-                )));
+                result.issues.push(
+                    Issue::error(
+                        "undefined_label",
+                        format!("未定義ラベル '{}' への条件ジャンプが存在します", label),
+                    )
+                    .with_suggestion(format!(
+                        "'[LABEL name={}]' を追加するか、ジャンプ先を修正してください",
+                        label
+                    )),
+                );
             }
             AstNode::Branch { choices } => {
                 for choice in choices {
                     if !defined.contains(choice.target.as_str()) {
-                        result.issues.push(Issue::error(format!(
-                            "選択肢 '{}' のジャンプ先ラベル '{}' が存在しません",
-                            choice.label, choice.target
-                        )));
+                        result.issues.push(
+                            Issue::error(
+                                "undefined_label",
+                                format!(
+                                    "選択肢 '{}' のジャンプ先ラベル '{}' が存在しません",
+                                    choice.label, choice.target
+                                ),
+                            )
+                            .with_suggestion(format!(
+                                "'[LABEL name={}]' を追加するか、選択肢のラベル参照を修正してください",
+                                choice.target
+                            )),
+                        );
                     }
                 }
             }
@@ -191,10 +243,10 @@ fn check_reachability(ast: &Ast, _defined: &HashSet<&str>, result: &mut Analysis
     // 定義されているが一度も参照されないラベルは情報として報告
     for label in ast.labels.keys() {
         if !referenced.contains(label.as_str()) {
-            result.issues.push(Issue::info(format!(
-                "ラベル '{}' はどこからも参照されていません",
-                label
-            )));
+            result.issues.push(Issue::info(
+                "unreferenced_label",
+                format!("ラベル '{}' はどこからも参照されていません", label),
+            ));
         }
     }
 }
@@ -204,12 +256,16 @@ fn check_empty_branches(ast: &Ast, result: &mut AnalysisResult) {
     for node in &ast.nodes {
         if let AstNode::Branch { choices } = node {
             if choices.is_empty() {
-                result.issues.push(Issue::error(
-                    "BRANCH 命令に選択肢が1つもありません".to_string(),
-                ));
+                result.issues.push(
+                    Issue::error("empty_branch", "BRANCH 命令に選択肢が1つもありません")
+                        .with_suggestion(
+                            "choice=テキスト label=ラベル名 の形式で選択肢を追加してください",
+                        ),
+                );
             } else if choices.len() == 1 {
                 result.issues.push(Issue::warning(
-                    "BRANCH 命令の選択肢が1つしかありません（分岐になっていません）".to_string(),
+                    "single_choice_branch",
+                    "BRANCH 命令の選択肢が1つしかありません（分岐になっていません）",
                 ));
             }
         }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -34,7 +34,7 @@ pub struct Span {
 /// 検査で発見した1件の問題（Diagnostic）
 ///
 /// `rule_id` でルール種別を機械的に識別できる。
-/// `span` は将来的にパーサーが行番号を付与したときに利用する（現在は None）。
+/// `span` / `related_spans` は将来的にパーサーが行番号を付与したときに利用する（現在は None / []）。
 /// `suggestion` があれば修正方法をユーザーに提示する。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Issue {
@@ -42,6 +42,7 @@ pub struct Issue {
     pub level: Level,
     pub message: String,
     pub span: Option<Span>,
+    pub related_spans: Vec<Span>,
     pub suggestion: Option<String>,
 }
 
@@ -67,6 +68,7 @@ impl CheckJsonOutput {
                 level: Level::Error,
                 message,
                 span: None,
+                related_spans: vec![],
                 suggestion: None,
             }],
         }
@@ -91,6 +93,7 @@ impl Issue {
             level: Level::Error,
             message: msg.into(),
             span: None,
+            related_spans: vec![],
             suggestion: None,
         }
     }
@@ -101,6 +104,7 @@ impl Issue {
             level: Level::Warning,
             message: msg.into(),
             span: None,
+            related_spans: vec![],
             suggestion: None,
         }
     }
@@ -111,6 +115,7 @@ impl Issue {
             level: Level::Info,
             message: msg.into(),
             span: None,
+            related_spans: vec![],
             suggestion: None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,10 @@ fn main() -> anyhow::Result<()> {
                         tsumugai::analyzer::Level::Warning => "警告",
                         tsumugai::analyzer::Level::Info => "情報",
                     };
-                    println!("[{}] {}", level, issue.message);
+                    println!("[{}][{}] {}", level, issue.rule_id, issue.message);
+                    if let Some(suggestion) = &issue.suggestion {
+                        println!("  提案: {}", suggestion);
+                    }
                 }
                 println!(
                     "\nエラー: {}件  警告: {}件",


### PR DESCRIPTION
closes #36

## 変更内容

### Rust コードを読まなくても分かる変化

**`tsumugai check` の出力が変わりました（人間向け）:**

変更前:
```
[エラー] 未定義ラベル 'good_end' へのジャンプが存在します
```

変更後:
```
[エラー][undefined_label] 未定義ラベル 'good_end' へのジャンプが存在します
  提案: '[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください
```

**JSON 出力に `rule_id` / `span` / `suggestion` が追加されました:**

```json
{
  "rule_id": "undefined_label",
  "level": "error",
  "message": "未定義ラベル 'good_end' へのジャンプが存在します",
  "span": null,
  "suggestion": "'[LABEL name=good_end]' を追加するか、ジャンプ先を修正してください"
}
```

## 変更ファイル

- `src/analyzer/mod.rs` — `Span` 型追加、`Issue` に `rule_id` / `span` / `suggestion` を追加、各チェックルールを更新
- `src/main.rs` — 人間向け出力に `rule_id` と `suggestion` を追加
- `docs/DIAGNOSTIC.md` — 型設計・rule_id 一覧・JSON 例・CLI 表示例を新設

## rule_id 一覧

| rule_id | level | 内容 |
|:---|:---|:---|
| `undefined_label` | Error | 未定義ラベルへのジャンプ・選択肢参照 |
| `unreferenced_label` | Info | どこからも参照されていないラベル |
| `empty_branch` | Error | 選択肢が0個の BRANCH |
| `single_choice_branch` | Warning | 選択肢が1個しかない BRANCH |
| `parse_error` | Error | パース失敗 |

## span について

`Span { line, column }` 型はすでに定義・直列化対応済みですが、パーサーが行番号を AstNode に付与するまで常に `null` です。API の形式は変わりません。

## 検証

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` ✓（45 テスト全通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 診断モデルと出力仕様を拡張して文書化：ルールID、レベル、日本語メッセージ、位置情報・関連位置、任意の修正提案、JSONスキーマとヒューマンリーダブルな表示例を追加（現状の位置情報取り扱いと今後の方針を記録）。
* **New Features**
  * チェック出力に各問題のルールIDを表示。
  * 提案がある場合はCLI表示で提案行を併記。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->