### PR TITLE
feat: Runtime Trace の最小実装を追加する (#38)

### DIFF
--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -1,0 +1,146 @@
+# Runtime Trace 設計
+
+関連issue: #38
+
+## 概要
+
+`RuntimeTrace` は、シナリオを自動実行したときの「どの入力を与え、何が起き、状態がどう変わったか」を step 単位で記録する。
+
+LLM にトレースを貼って「なぜこの台詞が出たか」「なぜこのルートに入ったか」を分析してもらう用途を想定する。
+
+---
+
+## 型定義
+
+```rust
+pub struct RuntimeTrace {
+    pub total_steps: usize,
+    /// MAX_STEPS(1000) に達した場合は true（無限ループ保護）
+    pub truncated: bool,
+    pub steps: Vec<TraceStep>,
+}
+
+pub struct TraceStep {
+    pub step_no: usize,
+    pub pc_before: usize,
+    /// 与えた入力。最初の step は null
+    pub input: Option<String>,
+    pub pc_after: usize,
+    pub events: Vec<Event>,
+    pub state_diff: StateDiff,
+    /// 次に何を待っているか。null = シナリオ終了
+    pub waiting_for: Option<String>,
+}
+
+pub struct StateDiff {
+    pub var_changes: Vec<VarChange>,
+}
+
+pub struct VarChange {
+    pub key: String,
+    pub before: Option<String>,  // 新規追加の場合は None
+    pub after: String,
+}
+```
+
+---
+
+## 実行モデル
+
+`trace_linear` は選択肢を常に先頭（表示条件を満たすもの）から選ぶ。
+
+```
+step(state, program, None)
+  → waiting_for = Advance → step(_, _, Some(Advance))
+  → waiting_for = Choice([opt0, opt1]) → step(_, _, Some(SelectChoice(opt0.id)))
+  → waiting_for = Ended → 終了
+```
+
+各 `runtime::step()` 呼び出しが 1 つの `TraceStep` に対応する。
+
+---
+
+## CLI
+
+```bash
+# 人間向け出力
+tsumugai trace scenario.md
+
+# JSON 出力（CI・Golden テスト・LLM デバッグ用）
+tsumugai trace scenario.md --json
+```
+
+---
+
+## 人間向け出力例
+
+```
+=== Runtime Trace (3 steps) ===
+
+Step 0 (pc 0 → 1)
+  Input   : (初回実行)
+  Event   : Say(Alice): こんにちは！
+  State   : (変化なし)
+  Waiting : Advance
+
+Step 1 (pc 1 → 2)
+  Input   : Advance
+  Events  : (なし)
+  State   : (変化なし)
+  Waiting : (終了)
+```
+
+---
+
+## JSON 出力例
+
+```json
+{
+  "status": "ok",
+  "trace": {
+    "total_steps": 3,
+    "truncated": false,
+    "steps": [
+      {
+        "step_no": 0,
+        "pc_before": 0,
+        "input": null,
+        "pc_after": 1,
+        "events": [{ "Say": { "speaker": "Alice", "text": "こんにちは！" } }],
+        "state_diff": { "var_changes": [] },
+        "waiting_for": "Advance"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 変数変化の例
+
+`[SET name=score value=10]` を実行すると：
+
+```json
+"state_diff": {
+  "var_changes": [
+    { "key": "score", "before": null, "after": "10" }
+  ]
+}
+```
+
+`[MODIFY name=score op=add value=5]` の後は：
+
+```json
+"var_changes": [
+  { "key": "score", "before": "10", "after": "15" }
+]
+```
+
+---
+
+## 現時点の制約
+
+- `trace_linear` は「常に先頭選択肢を選ぶ」単一ルートのみトレースする
+- 全分岐を探索する DFS/BFS トレースは [Dry Run Report (#40)](https://github.com/kosuke-fujisawa/tsumugai/issues/40) で扱う
+- パーサーが行番号を付与していないため、`span` は現時点で持たない

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 //! tsumugai CLI エントリーポイント
 
 use std::fs;
+use tsumugai::runtime::ir::Event;
+use tsumugai::runtime::trace::RuntimeTrace;
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -10,6 +12,8 @@ fn main() -> anyhow::Result<()> {
         "コマンド:\n",
         "  check <file>         シナリオの静的検証（人間向け出力）\n",
         "  check <file> --json  シナリオの静的検証（JSON出力）\n",
+        "  trace <file>         シナリオの実行トレース（先頭選択肢を自動選択）\n",
+        "  trace <file> --json  シナリオの実行トレース（JSON出力）\n",
         "  play  <file>         シナリオの対話再生\n",
         "  play  <file> --debug デバッグ情報付きで再生"
     );
@@ -79,6 +83,44 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         }
+        "trace" => {
+            let ast = match tsumugai::parser::parse(&markdown) {
+                Ok(ast) => ast,
+                Err(e) => {
+                    if json_mode {
+                        let trace = tsumugai::runtime::trace::RuntimeTrace {
+                            total_steps: 0,
+                            truncated: false,
+                            steps: vec![],
+                        };
+                        let output = tsumugai::runtime::trace::TraceJsonOutput {
+                            status: "error",
+                            trace,
+                        };
+                        println!("{}", serde_json::to_string_pretty(&output)?);
+                        std::process::exit(1);
+                    } else {
+                        return Err(e);
+                    }
+                }
+            };
+
+            let program = tsumugai::runtime::compile(&ast);
+            let trace = tsumugai::runtime::trace::trace_linear(&program);
+
+            if json_mode {
+                let output = tsumugai::runtime::trace::TraceJsonOutput {
+                    status: "ok",
+                    trace,
+                };
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            } else {
+                print_trace_human(&trace);
+                if trace.truncated {
+                    eprintln!("警告: ステップ数の上限に達したため打ち切られました。");
+                }
+            }
+        }
         _ => {
             eprintln!("不明なコマンド: {}\n{}", command, usage);
             std::process::exit(1);
@@ -86,4 +128,59 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn print_trace_human(trace: &RuntimeTrace) {
+    println!("=== Runtime Trace ({} steps) ===\n", trace.total_steps);
+    for step in &trace.steps {
+        println!(
+            "Step {} (pc {} → {})",
+            step.step_no, step.pc_before, step.pc_after
+        );
+        if let Some(input) = &step.input {
+            println!("  Input   : {}", input);
+        } else {
+            println!("  Input   : (初回実行)");
+        }
+        if step.events.is_empty() {
+            println!("  Events  : (なし)");
+        } else {
+            for event in &step.events {
+                println!("  Event   : {}", describe_event(event));
+            }
+        }
+        if step.state_diff.var_changes.is_empty() {
+            println!("  State   : (変化なし)");
+        } else {
+            for change in &step.state_diff.var_changes {
+                match &change.before {
+                    None => println!("  State   : {} = {} (新規)", change.key, change.after),
+                    Some(before) => {
+                        println!("  State   : {} {} → {}", change.key, before, change.after)
+                    }
+                }
+            }
+        }
+        match &step.waiting_for {
+            None => println!("  Waiting : (終了)"),
+            Some(w) => println!("  Waiting : {}", w),
+        }
+        println!();
+    }
+}
+
+fn describe_event(event: &Event) -> String {
+    match event {
+        Event::Say { speaker, text } if speaker.is_empty() => format!("Narration: {}", text),
+        Event::Say { speaker, text } => format!("Say({}): {}", speaker, text),
+        Event::SceneStart { name } => format!("SceneStart: {}", name),
+        Event::ShowImage { layer, name } => format!("ShowImage: {} / {}", layer, name),
+        Event::ClearLayer { layer } => format!("ClearLayer: {}", layer),
+        Event::PlayBgm { name } => format!("PlayBgm: {}", name),
+        Event::PlaySe { name } => format!("PlaySe: {}", name),
+        Event::PlayMovie { name } => format!("PlayMovie: {}", name),
+        Event::Wait { duration } => format!("Wait: {}s", duration),
+        Event::Ending { id, name } => format!("Ending: {} ({})", name, id),
+        Event::Custom { tag, params } => format!("Custom[{}]: {}", tag, params.join(", ")),
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,6 +16,7 @@
 //! - 状態は明示的（隠れた状態を持たない）
 
 pub mod ir;
+pub mod trace;
 
 use crate::types::{
     ast::{Ast, AstNode, Comparison, Expr, Operation},

--- a/src/runtime/trace.rs
+++ b/src/runtime/trace.rs
@@ -1,0 +1,300 @@
+//! Runtime Trace — シナリオ実行の追跡
+//!
+//! `trace_linear` は選択肢を常に先頭から選ぶ自動実行を行い、
+//! 各 step の入力・出力・状態変化を `RuntimeTrace` として返す。
+//!
+//! # 使い方
+//! ```no_run
+//! use tsumugai::{parser, runtime};
+//! use tsumugai::runtime::trace::trace_linear;
+//!
+//! let md = "...";
+//! let ast = parser::parse(md).unwrap();
+//! let program = runtime::compile(&ast);
+//! let trace = trace_linear(&program);
+//! ```
+
+use crate::runtime::ir::{Event, Program};
+use crate::runtime::{Input, WaitingType, step};
+use crate::types::state::State;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// 無限ループ保護：これ以上 step したら打ち切る
+const MAX_STEPS: usize = 1000;
+
+// ──────────────────────────────────────────────
+// 型定義
+// ──────────────────────────────────────────────
+
+/// 1変数の変化
+#[derive(Debug, Clone, Serialize)]
+pub struct VarChange {
+    pub key: String,
+    /// 変化前の値（新規追加の場合は None）
+    pub before: Option<String>,
+    pub after: String,
+}
+
+/// 1 step での状態差分
+#[derive(Debug, Clone, Serialize)]
+pub struct StateDiff {
+    pub var_changes: Vec<VarChange>,
+}
+
+/// 1 step（`runtime::step()` 1回分）の記録
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceStep {
+    pub step_no: usize,
+    /// step 呼び出し前の PC
+    pub pc_before: usize,
+    /// この step に与えた入力（最初の step は null）
+    pub input: Option<String>,
+    /// step 呼び出し後の PC
+    pub pc_after: usize,
+    /// この step で発生したイベント
+    pub events: Vec<Event>,
+    /// 変数の変化
+    pub state_diff: StateDiff,
+    /// 次に何を待っているか（null ならシナリオ終了）
+    pub waiting_for: Option<String>,
+}
+
+/// シナリオ1回の実行トレース全体
+#[derive(Debug, Serialize)]
+pub struct RuntimeTrace {
+    pub total_steps: usize,
+    /// 無限ループ等で MAX_STEPS に達した場合は true
+    pub truncated: bool,
+    pub steps: Vec<TraceStep>,
+}
+
+/// `--json` 出力用ラッパー
+#[derive(Debug, Serialize)]
+pub struct TraceJsonOutput {
+    pub status: &'static str,
+    pub trace: RuntimeTrace,
+}
+
+// ──────────────────────────────────────────────
+// 線形トレース（常に先頭選択肢を選ぶ自動実行）
+// ──────────────────────────────────────────────
+
+/// プログラムを自動実行して `RuntimeTrace` を返す
+///
+/// 選択肢は常に先頭（表示条件を満たすもの）を選ぶ。
+/// `MAX_STEPS` を超えると打ち切り `truncated = true` になる。
+pub fn trace_linear(program: &Program) -> RuntimeTrace {
+    let mut state = State::new();
+    let mut steps: Vec<TraceStep> = Vec::new();
+    let mut input: Option<Input> = None;
+    let mut truncated = false;
+
+    for step_no in 0..MAX_STEPS {
+        let pc_before = state.pc;
+        let flags_before = state.flags.clone();
+        let input_label = input.as_ref().map(describe_input);
+
+        let (new_state, output) = step(state, program, input.take());
+        state = new_state;
+
+        let var_changes = diff_flags(&flags_before, &state.flags);
+        let waiting_label = output.waiting_for.as_ref().map(describe_waiting);
+
+        steps.push(TraceStep {
+            step_no,
+            pc_before,
+            input: input_label,
+            pc_after: state.pc,
+            events: output.events,
+            state_diff: StateDiff { var_changes },
+            waiting_for: waiting_label,
+        });
+
+        input = match &output.waiting_for {
+            None => break,
+            Some(WaitingType::Advance) => Some(Input::Advance),
+            Some(WaitingType::Choice(opts)) => {
+                if let Some(first) = opts.first() {
+                    Some(Input::SelectChoice(first.id.clone()))
+                } else {
+                    break;
+                }
+            }
+            Some(WaitingType::Ended { .. }) => break,
+        };
+
+        if step_no + 1 == MAX_STEPS {
+            truncated = true;
+        }
+    }
+
+    let total = steps.len();
+    RuntimeTrace {
+        total_steps: total,
+        truncated,
+        steps,
+    }
+}
+
+// ──────────────────────────────────────────────
+// ヘルパー
+// ──────────────────────────────────────────────
+
+fn describe_input(input: &Input) -> String {
+    match input {
+        Input::Advance => "Advance".to_string(),
+        Input::SelectChoice(id) => format!("SelectChoice({})", id),
+    }
+}
+
+fn describe_waiting(waiting: &WaitingType) -> String {
+    match waiting {
+        WaitingType::Advance => "Advance".to_string(),
+        WaitingType::Choice(opts) => {
+            let labels: Vec<&str> = opts.iter().map(|o| o.label.as_str()).collect();
+            format!("Choice({})", labels.join(" / "))
+        }
+        WaitingType::Ended { id, name } => format!("Ended(id={}, name={})", id, name),
+    }
+}
+
+fn describe_flag_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn diff_flags(
+    before: &HashMap<String, serde_json::Value>,
+    after: &HashMap<String, serde_json::Value>,
+) -> Vec<VarChange> {
+    let mut changes = Vec::new();
+
+    for (key, after_val) in after {
+        let before_val = before.get(key);
+        match before_val {
+            None => changes.push(VarChange {
+                key: key.clone(),
+                before: None,
+                after: describe_flag_value(after_val),
+            }),
+            Some(b) if b != after_val => changes.push(VarChange {
+                key: key.clone(),
+                before: Some(describe_flag_value(b)),
+                after: describe_flag_value(after_val),
+            }),
+            _ => {}
+        }
+    }
+
+    // 削除されたキーも記録（現時点では State は変数を削除しないが念のため）
+    for (key, before_val) in before {
+        if !after.contains_key(key) {
+            changes.push(VarChange {
+                key: key.clone(),
+                before: Some(describe_flag_value(before_val)),
+                after: "(removed)".to_string(),
+            });
+        }
+    }
+
+    changes.sort_by(|a, b| a.key.cmp(&b.key));
+    changes
+}
+
+// ──────────────────────────────────────────────
+// テスト
+// ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{parser::parse, runtime::compile};
+
+    #[test]
+    fn 台詞のトレース() {
+        let md = "[SAY speaker=Alice]\nこんにちは！\n";
+        let ast = parse(md).unwrap();
+        let program = compile(&ast);
+        let trace = trace_linear(&program);
+
+        assert!(!trace.truncated);
+        // step 0: None → Say + AwaitAdvance
+        // step 1: Advance → プログラム末尾
+        assert_eq!(trace.total_steps, 2);
+        assert_eq!(trace.steps[0].input, None);
+        assert_eq!(trace.steps[0].events.len(), 1);
+        assert_eq!(trace.steps[0].waiting_for.as_deref(), Some("Advance"));
+        assert_eq!(trace.steps[1].input.as_deref(), Some("Advance"));
+        assert_eq!(trace.steps[1].waiting_for, None);
+    }
+
+    #[test]
+    fn 選択肢のトレース_先頭選択() {
+        let md = r#"
+[BRANCH choice=はい label=yes, choice=いいえ label=no]
+
+[LABEL name=yes]
+[SAY speaker=Alice]
+選んだ。
+
+[LABEL name=no]
+[SAY speaker=Alice]
+選ばなかった。
+"#;
+        let ast = parse(md).unwrap();
+        let program = compile(&ast);
+        let trace = trace_linear(&program);
+
+        assert!(!trace.truncated);
+        // step 0: None → AwaitChoice
+        assert!(
+            trace.steps[0]
+                .waiting_for
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("Choice(")
+        );
+        // step 1: SelectChoice → Say + AwaitAdvance
+        assert!(
+            trace.steps[1]
+                .input
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("SelectChoice(")
+        );
+    }
+
+    #[test]
+    fn 変数変化がトレースに記録される() {
+        let md = "[SET name=score value=10]\n[SAY speaker=Alice]\nテスト\n";
+        let ast = parse(md).unwrap();
+        let program = compile(&ast);
+        let trace = trace_linear(&program);
+
+        // SET は step 0 の中で実行される
+        let changes = &trace.steps[0].state_diff.var_changes;
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].key, "score");
+        assert_eq!(changes[0].before, None);
+        assert_eq!(changes[0].after, "10");
+    }
+
+    #[test]
+    fn エンディング到達で終了() {
+        let md = "[SAY speaker=Alice]\n終わり\n\n[ENDING id=end1]\n";
+        let ast = parse(md).unwrap();
+        let program = compile(&ast);
+        let trace = trace_linear(&program);
+
+        let last = trace.steps.last().unwrap();
+        assert!(
+            last.waiting_for
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("Ended(")
+        );
+    }
+}


### PR DESCRIPTION
## 概要

issue #38 の完了条件を満たす最小実装。

シナリオを自動実行（先頭選択肢を常に選ぶ）して、各 step の入力・イベント・変数変化を `RuntimeTrace` として記録できるようにした。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/runtime/trace.rs` | 新規。`RuntimeTrace` / `TraceStep` / `StateDiff` 型と `trace_linear()` 関数 |
| `src/runtime/mod.rs` | `pub mod trace;` を追加 |
| `src/main.rs` | `trace` コマンドを追加（人間向け出力 / `--json` 切り替え） |
| `docs/TRACE.md` | 新規。型定義・実行モデル・出力例の設計ドキュメント |

## CLI 出力例

### 人間向け（`tsumugai trace scenario.md`）

```
=== Runtime Trace (3 steps) ===

Step 0 (pc 0 → 1)
  Input   : (初回実行)
  Event   : Say(Alice): こんにちは！
  State   : (変化なし)
  Waiting : Advance

Step 1 (pc 1 → 2)
  Input   : Advance
  Event   : Say(Alice): さようなら。
  State   : (変化なし)
  Waiting : Advance

Step 2 (pc 2 → 3)
  Input   : Advance
  Events  : (なし)
  State   : (変化なし)
  Waiting : (終了)
```

### JSON（`tsumugai trace scenario.md --json`）

```json
{
  "status": "ok",
  "trace": {
    "total_steps": 3,
    "truncated": false,
    "steps": [
      {
        "step_no": 0,
        "pc_before": 0,
        "input": null,
        "pc_after": 1,
        "events": [{ "Say": { "speaker": "Alice", "text": "こんにちは！" } }],
        "state_diff": { "var_changes": [] },
        "waiting_for": "Advance"
      }
    ]
  }
}
```

変数変化がある場合は `state_diff.var_changes` に記録される（`before: null` = 新規追加）。

## 設計上の判断

- **1 step = `runtime::step()` 1回分**：複数 IR 命令を内包するが、入力の粒度と一致しており LLM に渡して分析しやすい
- **自動選択は「先頭表示条件付き選択肢」**：条件付き選択肢がある場合も条件を評価した上で先頭を選ぶ
- **無限ループ保護**：`MAX_STEPS = 1000` で打ち切り、`truncated = true` を立てる
- **全分岐探索は対象外**：DFS/BFS による全エンディング探索は issue #40（Dry Run Report）のスコープ

## 検証

```bash
cargo fmt --check    # ✓
cargo clippy --all-targets -- -D warnings    # ✓
cargo test    # ✓ 27+21+2 tests passed
```

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 実行トレース機能を追加しました。シナリオ実行をステップバイステップで記録し、入力、イベント、変数の変更、待機状態を表示できます。人間が読める形式またはJSON形式での出力に対応しています。

* **ドキュメント**
  * 実行トレース仕様に関するドキュメントを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->