### PR TITLE
feat: パーサーに行番号追跡を追加し Diagnostic の span を設定する

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -34,7 +34,7 @@ pub struct Span {
 /// 検査で発見した1件の問題（Diagnostic）
 ///
 /// `rule_id` でルール種別を機械的に識別できる。
-/// `span` / `related_spans` は将来的にパーサーが行番号を付与したときに利用する（現在は None / []）。
+/// `span` はパーサーが行番号を記録したノードに対して設定される（1-origin）。
 /// `suggestion` があれば修正方法をユーザーに提示する。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Issue {
@@ -124,6 +124,11 @@ impl Issue {
         self.suggestion = Some(suggestion.into());
         self
     }
+
+    fn with_span(mut self, span: Option<Span>) -> Self {
+        self.span = span;
+        self
+    }
 }
 
 /// 解析結果
@@ -179,9 +184,16 @@ pub fn analyze(ast: &Ast) -> AnalysisResult {
     result
 }
 
+fn node_span(ast: &Ast, idx: usize) -> Option<Span> {
+    ast.node_lines
+        .get(idx)
+        .map(|&line| Span { line, column: 1 })
+}
+
 /// ジャンプ先ラベルの存在確認
 fn check_label_references(ast: &Ast, defined: &HashSet<&str>, result: &mut AnalysisResult) {
-    for node in &ast.nodes {
+    for (idx, node) in ast.nodes.iter().enumerate() {
+        let span = node_span(ast, idx);
         match node {
             AstNode::Jump { label } if !defined.contains(label.as_str()) => {
                 result.issues.push(
@@ -189,6 +201,7 @@ fn check_label_references(ast: &Ast, defined: &HashSet<&str>, result: &mut Analy
                         "undefined_label",
                         format!("未定義ラベル '{}' へのジャンプが存在します", label),
                     )
+                    .with_span(span)
                     .with_suggestion(format!(
                         "'[LABEL name={}]' を追加するか、ジャンプ先を修正してください",
                         label
@@ -201,6 +214,7 @@ fn check_label_references(ast: &Ast, defined: &HashSet<&str>, result: &mut Analy
                         "undefined_label",
                         format!("未定義ラベル '{}' への条件ジャンプが存在します", label),
                     )
+                    .with_span(span)
                     .with_suggestion(format!(
                         "'[LABEL name={}]' を追加するか、ジャンプ先を修正してください",
                         label
@@ -218,6 +232,7 @@ fn check_label_references(ast: &Ast, defined: &HashSet<&str>, result: &mut Analy
                                     choice.label, choice.target
                                 ),
                             )
+                            .with_span(span.clone())
                             .with_suggestion(format!(
                                 "'[LABEL name={}]' を追加するか、選択肢のラベル参照を修正してください",
                                 choice.target
@@ -253,32 +268,41 @@ fn check_reachability(ast: &Ast, _defined: &HashSet<&str>, result: &mut Analysis
     }
 
     // 定義されているが一度も参照されないラベルは情報として報告
-    for label in ast.labels.keys() {
+    for (label, &node_idx) in &ast.labels {
         if !referenced.contains(label.as_str()) {
-            result.issues.push(Issue::info(
-                "unreferenced_label",
-                format!("ラベル '{}' はどこからも参照されていません", label),
-            ));
+            let span = node_span(ast, node_idx);
+            result.issues.push(
+                Issue::info(
+                    "unreferenced_label",
+                    format!("ラベル '{}' はどこからも参照されていません", label),
+                )
+                .with_span(span),
+            );
         }
     }
 }
 
 /// 空の選択肢チェック
 fn check_empty_branches(ast: &Ast, result: &mut AnalysisResult) {
-    for node in &ast.nodes {
+    for (idx, node) in ast.nodes.iter().enumerate() {
         if let AstNode::Branch { choices } = node {
+            let span = node_span(ast, idx);
             if choices.is_empty() {
                 result.issues.push(
                     Issue::error("empty_branch", "BRANCH 命令に選択肢が1つもありません")
+                        .with_span(span)
                         .with_suggestion(
                             "choice=テキスト label=ラベル名 の形式で選択肢を追加してください",
                         ),
                 );
             } else if choices.len() == 1 {
-                result.issues.push(Issue::warning(
-                    "single_choice_branch",
-                    "BRANCH 命令の選択肢が1つしかありません（分岐になっていません）",
-                ));
+                result.issues.push(
+                    Issue::warning(
+                        "single_choice_branch",
+                        "BRANCH 命令の選択肢が1つしかありません（分岐になっていません）",
+                    )
+                    .with_span(span),
+                );
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,9 @@ fn main() -> anyhow::Result<()> {
                         tsumugai::analyzer::Level::Info => "情報",
                     };
                     println!("[{}][{}] {}", level, issue.rule_id, issue.message);
+                    if let Some(span) = &issue.span {
+                        println!("  位置: {}行目", span.line);
+                    }
                     if let Some(suggestion) = &issue.suggestion {
                         println!("  提案: {}", suggestion);
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,6 +20,7 @@ struct MarkdownParser {
     lines: Vec<String>,
     current_line: usize,
     nodes: Vec<AstNode>,
+    node_lines: Vec<usize>,
     labels: HashMap<String, usize>,
     conditions: std::collections::HashSet<String>,
 }
@@ -31,6 +32,7 @@ impl MarkdownParser {
             lines,
             current_line: 0,
             nodes: Vec::new(),
+            node_lines: Vec::new(),
             labels: HashMap::new(),
             conditions: std::collections::HashSet::new(),
         }
@@ -46,11 +48,10 @@ impl MarkdownParser {
         // Second pass: validate labels
         self.validate_labels()?;
 
-        Ok(Ast::with_conditions(
-            self.nodes,
-            self.labels,
-            self.conditions,
-        ))
+        Ok(
+            Ast::with_conditions(self.nodes, self.labels, self.conditions)
+                .with_node_lines(self.node_lines),
+        )
     }
 
     fn parse_line(&mut self) -> anyhow::Result<()> {
@@ -82,6 +83,7 @@ impl MarkdownParser {
                 self.labels.insert(name.clone(), self.nodes.len());
             }
 
+            self.node_lines.push(self.current_line + 1); // 1-origin
             self.nodes.push(node);
         }
 

--- a/src/types/ast.rs
+++ b/src/types/ast.rs
@@ -11,6 +11,9 @@ pub struct Ast {
     pub labels: HashMap<String, usize>,
     /// 宣言済み条件名（:::conditions ブロックから）
     pub conditions: std::collections::HashSet<String>,
+    /// ノードインデックス → ソース行番号（1-origin）。パーサーが設定する
+    #[serde(default, skip_serializing)]
+    pub node_lines: Vec<usize>,
 }
 
 impl Ast {
@@ -19,6 +22,7 @@ impl Ast {
             nodes,
             labels,
             conditions: std::collections::HashSet::new(),
+            node_lines: Vec::new(),
         }
     }
 
@@ -31,7 +35,13 @@ impl Ast {
             nodes,
             labels,
             conditions,
+            node_lines: Vec::new(),
         }
+    }
+
+    pub fn with_node_lines(mut self, node_lines: Vec<usize>) -> Self {
+        self.node_lines = node_lines;
+        self
     }
 
     pub fn get_label_index(&self, label: &str) -> Option<usize> {


### PR DESCRIPTION
## 概要

Issue #31（Task 4: 診断情報の強化設計）の実装。
パーサーがソース行番号を記録し、アナライザーが `Issue.span` に設定するようにした。

## 変更内容

- `src/types/ast.rs`: `Ast` に `node_lines: Vec<usize>` フィールドを追加（`#[serde(default, skip_serializing)]` なので既存の JSON 出力に影響なし）
- `src/parser/mod.rs`: ノード追加時に `current_line + 1`（1-origin）を `node_lines` に記録
- `src/analyzer/mod.rs`:
  - `Issue::with_span()` ビルダーメソッドを追加
  - `node_span()` ヘルパー関数を追加
  - `check_label_references` / `check_reachability` / `check_empty_branches` が span を設定するよう更新
- `src/main.rs`: CLI `check` の人間向け出力に「位置: N行目」を追加

## 出力例（Rustコードを読まなくても確認できる変更内容）

**人間向け出力（`tsumugai check scenario.md`）:**

```
[警告][single_choice_branch] BRANCH 命令の選択肢が1つしかありません（分岐になっていません）
  位置: 4行目
```

**JSON 出力（`tsumugai check scenario.md --json`）:**

```json
{
  "rule_id": "single_choice_branch",
  "level": "warning",
  "message": "BRANCH 命令の選択肢が1つしかありません（分岐になっていません）",
  "span": { "line": 4, "column": 1 },
  "related_spans": [],
  "suggestion": null
}
```

## 検証

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` ✓（27 unit tests + 21 integration tests）

## 注意点

- `column` は現在常に `1`（パーサーは行内列位置を追跡していない）
- `Ast::node_lines` は serde skip のため Golden JSON や既存テストに影響なし

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 問題検出時にソース位置情報が追加されました。CLIの出力に各問題の行番号（「位置」）が表示されるようになり、マークダウンファイル内での問題箇所の特定が容易になります。複数の問題がある場合、どの行に何の問題があるのかが一目瞭然になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kosuke-fujisawa/tsumugai/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->