### PR TITLE
fix: 存在しない statusline.js を指す statusLine 設定を削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,1 @@
-{
-  "statusLine": {
-    "type": "command",
-    "command": "~/.claude/statusline.js"
-  }
-}
+{}


### PR DESCRIPTION
## 概要
プロジェクト設定 `.claude/settings.json` の `statusLine` が存在しない `~/.claude/statusline.js` を指しており、ユーザーグローバル設定のステータスラインを上書きして何も表示されない状態になっていました。壊れた設定を削除し、グローバル設定(`~/.claude/settings.json`)のステータスラインが適用されるようにします。

## 変更内容
- `.claude/settings.json` から存在しないスクリプトを参照する `statusLine` 設定を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * アプリの設定内容が整理され、不要な設定が削除されました。
  * 設定ファイルはよりシンプルな構成になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->