### PR TITLE
docs: TypeScript移行不採用に伴いREADME/CLAUDE.md/AGENTS.mdの注記を訂正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
-> **⚠️ TS移行中（2026-07-06〜）**
-> tsumugai は [epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99) のもと、TypeScript / Svelte / Vite ベースの Markdown-first HTML5 VN build system として作り直し中です。以下の Rust 向け記述（`parser`/`analyzer`/`runtime`/`player`/`types` という責務分離やDiagnostic方針など）は、**旧実装（`src/` 以下）にのみ適用**されます。TS実装（`packages/` 以下）向けの指針は、旧Rust実装削除時（issue #110）にこの文書を全面改訂して反映します。それまでの間、TS実装の設計判断は epic #99 とその子issue（#100〜#110）の本文を参照してください。
+> **注記（2026-07-08）**
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け記述は、引き続き `src/` 以下の現行実装にそのまま適用されます。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できるようにします。
 
 この文書は、Codex などの LLM エージェントが `tsumugai` を開発するときに必ず参照する行動指針です。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **⚠️ TS移行中（2026-07-06〜）**
-> tsumugai は [epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99) のもと、TypeScript / Svelte / Vite ベースの Markdown-first HTML5 VN build system として作り直し中です。以下の Rust 向け設計制約（trait/generic/macro回避など）は、**旧実装（`src/` 以下）にのみ適用**されます。TS実装（`packages/` 以下）向けの指針は、旧Rust実装削除時（issue #110）にこの文書を全面改訂して反映します。それまでの間、TS実装の設計判断は epic #99 とその子issue（#100〜#110）の本文を参照してください。
+> **注記（2026-07-08）**
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け設計制約・責務分離は、引き続き `src/` 以下の現行実装にそのまま適用されます。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できるようにします。
 
 この文書は、Claude Code などの LLM エージェントが `tsumugai` を開発するときに必ず参照する行動指針です。
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tsumugai
 
-> **⚠️ 方針転換中（2026-07-06〜）**
-> tsumugai は、英語圏 itch.io 向け短編HTML5ビジュアルノベル「A Familiar Shape of Love」を制作するための **Markdown-first VN build system**（TypeScript / Svelte / Vite）として作り直しています。以下に書かれている「Rust製 semantic runtime」としての説明は**旧方針**であり、TypeScript版MVP完成後に置き換えられます。新方針の詳細と進捗は [epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99) を参照してください。Rust実装（`src/`）はTS版MVP完成まで参照用に保持されます。
+> **注記（2026-07-08）**
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は検討の結果、不採用が確定しました。tsumugai は、以下に説明する通り Rust 製の semantic runtime / シナリオチェッカーとして維持します。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、外部の Web フロントエンド（arikoi の Svelte 製 player 等）向けに StoryBundle JSON を出力できるようにする予定です。連携は npm 依存ではなく CLI サブプロセス経由で行います。
 
 ---
 


### PR DESCRIPTION
## Summary
- epic #99(TypeScript/Svelte/Vite全面移行)は不採用が確定したため、PR #126で追加した「TS移行中」の注記を訂正
- tsumugaiはRust製semantic runtime / シナリオチェッカーとして維持する現状に合わせて記述を戻した
- 新たに追加予定の`compile --target web`コマンド(#128、StoryBundle JSON出力)への言及を追加
- 本文のRust向け説明・設計制約自体は変更していない(そもそも旧方針ではなく現行方針のため)

## Test plan
- [x] README/CLAUDE.md/AGENTS.mdの冒頭を読むだけで、tsumugaiがRust CLIとして維持されることが分かる
- [x] 各ファイルの本文(Rust向け説明)が変更されていないことを目視確認

Refs #99, #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)