### PR TITLE
feat: compile --target web でStoryBundle JSONを生成する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 > **注記（2026-07-08）**
-> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け記述は、引き続き `src/` 以下の現行実装にそのまま適用されます。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できるようにします。
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け記述は、引き続き `src/` 以下の現行実装にそのまま適用されます。`compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加済みで、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できます。
 
 この文書は、Codex などの LLM エージェントが `tsumugai` を開発するときに必ず参照する行動指針です。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 > **注記（2026-07-08）**
-> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け設計制約・責務分離は、引き続き `src/` 以下の現行実装にそのまま適用されます。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できるようにします。
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け設計制約・責務分離は、引き続き `src/` 以下の現行実装にそのまま適用されます。`compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加済みで、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できます。
 
 この文書は、Claude Code などの LLM エージェントが `tsumugai` を開発するときに必ず参照する行動指針です。
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tsumugai
 
 > **注記（2026-07-08）**
-> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は検討の結果、不採用が確定しました。tsumugai は、以下に説明する通り Rust 製の semantic runtime / シナリオチェッカーとして維持します。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、外部の Web フロントエンド（arikoi の Svelte 製 player 等）向けに StoryBundle JSON を出力できるようにする予定です。連携は npm 依存ではなく CLI サブプロセス経由で行います。
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は検討の結果、不採用が確定しました。tsumugai は、以下に説明する通り Rust 製の semantic runtime / シナリオチェッカーとして維持します。新たに `compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加し、外部の Web フロントエンド（arikoi の Svelte 製 player 等）向けに StoryBundle JSON を出力できるようになりました。連携は npm 依存ではなく CLI サブプロセス経由で行います。
 
 ---
 
@@ -135,6 +135,8 @@ cargo run -- check examples/spring/scenario/spring_001.md
 cargo run -- check examples/spring --format json      # CI・LLM 連携用 JSON
 cargo run -- check examples/spring --format sarif     # GitHub Code Scanning 用 SARIF
 cargo run -- fmt examples/fmt/before.md               # よくある書き方を v1 記法へ推測整形
+cargo run -- compile examples/spring/scenario/spring_001.md --target web --output story-bundle.json
+                                                       # arikoi 等の Web フロントエンド向け StoryBundle JSON を生成
 ```
 
 - `check`: v1 記法（SPEC.md）の静的検査。構文・リンク切れ・話者名の書き間違い・シーン ID 重複・アセット実在などを一括検出する

--- a/docs/API.md
+++ b/docs/API.md
@@ -102,6 +102,25 @@ let result = scenario::fmt_path(path);
 
 ---
 
+## 6.5. compile --target web（StoryBundle JSON 生成、#128）
+
+```rust
+let result = scenario::compile_path(path, &CompileOptions::default());
+// result: CompileResult { file, check: CheckResult, bundle: Option<StoryBundle> }
+```
+
+check と同じ実行前検査を行い、error があれば `bundle` は `None`（出力ファイルは書き出さない）。`StoryBundle` は arikoi 側の Svelte 製 player 向けの JSON で、tsumugai を npm 依存にせず CLI サブプロセス + JSON ファイルで疎結合するための契約。
+
+- `scenes: BundleScene[]`: 1 Markdown ファイル = 1 シーン。`steps` はリード部とセクションのブロックをファイル内の出現順に平坦化したもの（SPEC 5章のフォールスルーと同じ規則で実行される）
+- `BundleStep` は `narration` / `dialogue` / `choice` / `jump` / `ending` の 5 種類。現行の v1 記法に変数構文がないため `set_variable` は未実装
+- `jump` / `choice` の飛び先はソース表記ではなく `{ sceneId, stepIndex }` に解決済みで持つ
+- `assets: BundleAsset[]`: front matter の `background` / `bgm` をファイル横断で重複排除して収集する
+- `storyBuildId` はビルド時刻・乱数を使わず、bundle の内容から決定的に計算する（同じ入力は常に同じ ID になる）
+
+CLI: `tsumugai compile <file> --target web --output <path>`（`--target` は現在 `web` のみ対応）。
+
+---
+
 ## 7. JSON 出力
 
 `render_json` / `render_trace_json` / `render_routes_json` / `render_fmt_json` / `render_sarif` が機械向け出力を生成する。スキーマは [CLI_OUTPUT.md](CLI_OUTPUT.md) が正。
@@ -123,6 +142,7 @@ let result = scenario::fmt_path(path);
 - `tsumugai trace --choices`（[TRACE.md](TRACE.md)）
 - `tsumugai routes`（[ROUTES.md](ROUTES.md)）
 - `tsumugai fmt --write`（SPEC 7章）
+- `tsumugai compile --target web`（StoryBundle JSON 生成、#128）
 
 未実装:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,12 @@ fn main() -> anyhow::Result<()> {
         "      --no-assets                background / bgm の実在チェックを省略\n",
         "  fmt   <file>   よくある書き方を推測して v1 記法へ整形する（SPEC 7章）\n",
         "      --write                    整形結果をファイルに書き戻す（既定は表示のみ）\n",
-        "      --format human|json        出力形式（既定: human）"
+        "      --format human|json        出力形式（既定: human）\n",
+        "  compile <file> --target web --output <path>\n",
+        "                 Markdown シナリオから StoryBundle JSON を生成する（#128）\n",
+        "      --target web               出力形式（現在は web のみ対応）\n",
+        "      --output <path>            StoryBundle JSON の書き出し先\n",
+        "      --no-assets                background / bgm の実在チェックを省略"
     );
 
     if args.len() < 3 {
@@ -90,6 +95,40 @@ fn main() -> anyhow::Result<()> {
             if result.has_errors() {
                 std::process::exit(1);
             }
+        }
+        "compile" => {
+            let (target, output, options) = parse_compile_args(&args[3..], usage);
+            if target.is_empty() {
+                eprintln!("compile には --target web の指定が必要です\n{}", usage);
+                std::process::exit(1);
+            }
+            if target != "web" {
+                eprintln!(
+                    "--target には web のみ指定できます（指定: {}）\n{}",
+                    target, usage
+                );
+                std::process::exit(1);
+            }
+            let Some(output) = output else {
+                eprintln!("compile には --output <path> の指定が必要です\n{}", usage);
+                std::process::exit(1);
+            };
+            let result = scenario::compile_path(Path::new(file_path), &options);
+            if result.has_errors() {
+                println!("{}", scenario::render_human(&result.check));
+                std::process::exit(1);
+            }
+            let bundle = result.bundle.expect("エラーがなければ bundle がある");
+            let json = serde_json::to_string_pretty(&bundle)
+                .map_err(|e| anyhow::anyhow!("StoryBundle をシリアライズできません: {}", e))?;
+            fs::write(&output, &json)
+                .map_err(|e| anyhow::anyhow!("StoryBundle を書き出せません '{}': {}", output, e))?;
+            println!(
+                "StoryBundle を書き出しました: {} ({} scenes, {} assets)",
+                output,
+                bundle.scenes.len(),
+                bundle.assets.len()
+            );
         }
         _ => {
             eprintln!("不明なコマンド: {}\n{}", command, usage);
@@ -213,6 +252,45 @@ fn parse_routes_args(rest: &[String], usage: &str) -> (bool, scenario::RoutesOpt
         }
     }
     (json, options)
+}
+
+/// compile の引数を解釈する。返り値は (--target の値, --output の値, オプション)
+fn parse_compile_args(
+    rest: &[String],
+    usage: &str,
+) -> (String, Option<String>, scenario::CompileOptions) {
+    let mut target = String::new();
+    let mut output = None;
+    let mut options = scenario::CompileOptions::default();
+    let mut iter = rest.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--target" => {
+                target = match iter.next() {
+                    Some(v) => v.clone(),
+                    None => {
+                        eprintln!("--target には値を指定してください\n{}", usage);
+                        std::process::exit(1);
+                    }
+                };
+            }
+            "--output" => {
+                output = match iter.next() {
+                    Some(v) => Some(v.clone()),
+                    None => {
+                        eprintln!("--output には出力先パスを指定してください\n{}", usage);
+                        std::process::exit(1);
+                    }
+                };
+            }
+            "--no-assets" => options.check_assets = false,
+            other => {
+                eprintln!("不明なオプション: {}\n{}", other, usage);
+                std::process::exit(1);
+            }
+        }
+    }
+    (target, output, options)
 }
 
 /// fmt の引数を解釈する。返り値は (JSON 出力か, --write が指定されたか)

--- a/src/scenario/compile.rs
+++ b/src/scenario/compile.rs
@@ -1,0 +1,414 @@
+//! `compile --target web`（#128）: StoryBundle JSON 生成
+//!
+//! arikoi 側の Svelte 製 player が読み込む JSON を、既存の実行前検査
+//! （[`check_path`](super::check::check_path)）に通ったプロジェクトから生成する。
+//! tsumugai は npm ライブラリとして配布せず、CLI サブプロセス + JSON ファイルで
+//! Web フロントエンドと疎結合する（表示・アセット読み込みは compile 先の責務）。
+//!
+//! # 設計メモ
+//! - `story_build_id` はビルド時刻や乱数ではなく、bundle の内容から決定的に
+//!   計算する（FNV-1a）。同じ入力からは常に同じ ID になり、Golden JSON 比較
+//!   や arikoi 側のキャッシュ判定に使える
+//! - 1 ファイル = 1 [`super::Scene`] を 1 [`BundleScene`] に対応させ、
+//!   リード部とセクションのブロックをファイル内の出現順にそのまま `steps` へ
+//!   平坦化する。セクション終端に ending・ジャンプ・選択肢がなければ次の
+//!   セクションへ続けて実行される（SPEC 5章のフォールスルーと同じ規則）ため、
+//!   この平坦化だけで既存の実行モデルを再現できる
+//! - jump / choice の飛び先はソース表記（`#anchor` 等）のまま持たず、
+//!   `{ scene_id, step_index }` に解決済みの形で持たせる。これは
+//!   `check_path` を通過済み（broken-link なし）という前提で解決できる
+//! - 現行の v1 記法には変数（`set_variable`）に相当する構文がないため、
+//!   このステップ種別は実装しない（narration / dialogue / choice / jump /
+//!   ending の 5 種のみ）。構文が追加された時点で対応する
+
+use super::check::{CheckOptions, CheckResult, check_path};
+use super::diagnostic::Severity;
+use super::project::{LoadedScene, file_level, load_project, resolve_sibling};
+use super::{Block, LinkTarget, Scene};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+const SCHEMA_VERSION: &str = "1";
+
+/// compile の動作オプション
+#[derive(Debug, Clone)]
+pub struct CompileOptions {
+    /// background / bgm の実在チェック（`--no-assets` で false）
+    pub check_assets: bool,
+}
+
+impl Default for CompileOptions {
+    fn default() -> Self {
+        Self { check_assets: true }
+    }
+}
+
+/// compile の結果。実行前検査（check と同じ規則）の結果を必ず含む
+#[derive(Debug)]
+pub struct CompileResult {
+    /// 開始シーンとして指定されたパス
+    pub file: PathBuf,
+    /// 実行前検査の結果
+    pub check: CheckResult,
+    /// 生成した StoryBundle。check が error のときは None
+    pub bundle: Option<StoryBundle>,
+}
+
+impl CompileResult {
+    /// exit code を 1 にすべきか（check エラー）
+    pub fn has_errors(&self) -> bool {
+        self.check.has_errors()
+    }
+}
+
+/// arikoi 側の Svelte 製 player が読み込む StoryBundle
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoryBundle {
+    pub schema_version: String,
+    /// bundle の内容から決定的に計算した ID（ビルド時刻・乱数は使わない）
+    pub story_build_id: String,
+    pub title: String,
+    pub entry_scene_id: String,
+    pub scenes: Vec<BundleScene>,
+    pub assets: Vec<BundleAsset>,
+}
+
+/// シナリオ Markdown 上の位置（arikoi 側のデバッグ表示用）
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SourceLocation {
+    pub file: String,
+    pub line: usize,
+}
+
+/// 1 ファイル = 1 シーン（[`super::Scene`] に対応）
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleScene {
+    pub id: String,
+    pub title: Option<String>,
+    pub source: SourceLocation,
+    pub steps: Vec<BundleStep>,
+}
+
+/// 飛び先。ソース表記ではなく、解決済みの scene 内インデックスで持つ
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StepTarget {
+    pub scene_id: String,
+    pub step_index: usize,
+}
+
+/// 選択肢 1 項目
+#[derive(Debug, Clone, Serialize)]
+pub struct ChoiceOption {
+    pub label: String,
+    pub target: StepTarget,
+    pub source: SourceLocation,
+}
+
+/// 1 ステップ（SPEC 4章のブロックに対応。set_variable は現行記法に無いため未実装）
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BundleStep {
+    Narration {
+        text: String,
+        source: SourceLocation,
+    },
+    Dialogue {
+        speaker: String,
+        text: String,
+        source: SourceLocation,
+    },
+    Choice {
+        items: Vec<ChoiceOption>,
+        source: SourceLocation,
+    },
+    Jump {
+        target: StepTarget,
+        source: SourceLocation,
+    },
+    Ending {
+        id: String,
+        source: SourceLocation,
+    },
+}
+
+/// アセット参照（現行記法にある background / bgm のみ）
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BundleAsset {
+    Background { path: String },
+    Bgm { path: String },
+}
+
+/// シーンファイルを実行前検査してから StoryBundle を生成する（#128）。
+///
+/// パスが存在しない・ディレクトリ・検査 error の場合も panic や Err にせず、
+/// Diagnostic 入りの [`CompileResult`] を返す（bundle は None になる）。
+pub fn compile_path(path: &Path, options: &CompileOptions) -> CompileResult {
+    if path.is_dir() {
+        let diag = file_level(
+            "io-error",
+            Severity::Error,
+            path,
+            format!(
+                "{} はディレクトリです。compile は開始するシーンファイル（.md）を 1 つ指定してください",
+                path.display()
+            ),
+        );
+        return CompileResult {
+            file: path.to_path_buf(),
+            check: CheckResult {
+                files: Vec::new(),
+                diagnostics: vec![diag],
+            },
+            bundle: None,
+        };
+    }
+
+    let check_options = CheckOptions {
+        check_assets: options.check_assets,
+    };
+    let mut check = check_path(path, &check_options);
+    if check.has_errors() {
+        return CompileResult {
+            file: path.to_path_buf(),
+            check,
+            bundle: None,
+        };
+    }
+
+    let mut load_diagnostics = Vec::new();
+    let scenes = load_project(vec![path.to_path_buf()], &mut load_diagnostics);
+    check.diagnostics.extend(load_diagnostics);
+    if check.has_errors() || scenes.is_empty() {
+        return CompileResult {
+            file: path.to_path_buf(),
+            check,
+            bundle: None,
+        };
+    }
+
+    let bundle = build_bundle(&scenes, path);
+    CompileResult {
+        file: path.to_path_buf(),
+        check,
+        bundle: Some(bundle),
+    }
+}
+
+// -------------------------------------------------------------- bundle構築
+
+fn build_bundle(scenes: &[LoadedScene], entry: &Path) -> StoryBundle {
+    let scene_ids: Vec<String> = scenes
+        .iter()
+        .map(|s| s.parsed.scene.id.clone().expect("check済みなのでidがある"))
+        .collect();
+    let layouts: Vec<Vec<usize>> = scenes
+        .iter()
+        .map(|s| segment_offsets(&s.parsed.scene))
+        .collect();
+
+    let entry_canon = entry.canonicalize().expect("check済みなので実在する");
+    let entry_idx = scenes
+        .iter()
+        .position(|s| s.canon == entry_canon)
+        .expect("entry はロード済み");
+
+    let bundle_scenes: Vec<BundleScene> = scenes
+        .iter()
+        .enumerate()
+        .map(|(i, loaded)| build_scene(i, loaded, scenes, &scene_ids, &layouts))
+        .collect();
+
+    let mut assets: Vec<BundleAsset> = scenes
+        .iter()
+        .flat_map(|s| {
+            let md = &s.parsed.scene;
+            let mut a = Vec::new();
+            if let Some(bg) = &md.background {
+                a.push(BundleAsset::Background { path: bg.clone() });
+            }
+            if let Some(bgm) = &md.bgm {
+                a.push(BundleAsset::Bgm { path: bgm.clone() });
+            }
+            a
+        })
+        .collect();
+    assets.sort();
+    assets.dedup();
+
+    let title = scenes[entry_idx]
+        .parsed
+        .scene
+        .title
+        .clone()
+        .unwrap_or_else(|| scene_ids[entry_idx].clone());
+
+    let mut bundle = StoryBundle {
+        schema_version: SCHEMA_VERSION.to_string(),
+        story_build_id: String::new(),
+        title,
+        entry_scene_id: scene_ids[entry_idx].clone(),
+        scenes: bundle_scenes,
+        assets,
+    };
+    bundle.story_build_id = compute_build_id(&bundle);
+    bundle
+}
+
+/// セグメント（`seg` 0 = リード部、`seg` n = `sections[n-1]`）の開始 step
+/// インデックス。長さは `sections.len() + 1`
+fn segment_offsets(scene: &Scene) -> Vec<usize> {
+    let mut offsets = Vec::with_capacity(scene.sections.len() + 1);
+    let mut cursor = 0usize;
+    offsets.push(cursor);
+    cursor += scene.lead.len();
+    for section in &scene.sections {
+        offsets.push(cursor);
+        cursor += section.blocks.len();
+    }
+    offsets
+}
+
+fn build_scene(
+    idx: usize,
+    loaded: &LoadedScene,
+    scenes: &[LoadedScene],
+    scene_ids: &[String],
+    layouts: &[Vec<usize>],
+) -> BundleScene {
+    let md = &loaded.parsed.scene;
+    let file = loaded.path.display().to_string();
+    let blocks = md
+        .lead
+        .iter()
+        .chain(md.sections.iter().flat_map(|s| s.blocks.iter()));
+    let steps = blocks
+        .map(|block| build_step(block, &file, scenes, scene_ids, layouts, idx))
+        .collect();
+
+    BundleScene {
+        id: scene_ids[idx].clone(),
+        title: md.title.clone(),
+        source: SourceLocation {
+            file: file.clone(),
+            line: 1,
+        },
+        steps,
+    }
+}
+
+fn build_step(
+    block: &Block,
+    file: &str,
+    scenes: &[LoadedScene],
+    scene_ids: &[String],
+    layouts: &[Vec<usize>],
+    current: usize,
+) -> BundleStep {
+    let src = |line: usize| SourceLocation {
+        file: file.to_string(),
+        line,
+    };
+    match block {
+        Block::Narration { text, line } => BundleStep::Narration {
+            text: text.clone(),
+            source: src(*line),
+        },
+        Block::Dialogue {
+            speaker,
+            text,
+            line,
+        } => BundleStep::Dialogue {
+            speaker: speaker.clone(),
+            text: text.clone(),
+            source: src(*line),
+        },
+        Block::Ending { id, line } => BundleStep::Ending {
+            id: id.clone(),
+            source: src(*line),
+        },
+        Block::Jump { target, line, .. } => BundleStep::Jump {
+            target: resolve_target(scenes, scene_ids, layouts, current, target),
+            source: src(*line),
+        },
+        Block::Choices { items, line } => BundleStep::Choice {
+            items: items
+                .iter()
+                .map(|item| ChoiceOption {
+                    label: item.label.clone(),
+                    target: resolve_target(scenes, scene_ids, layouts, current, &item.target),
+                    source: src(item.line),
+                })
+                .collect(),
+            source: src(*line),
+        },
+    }
+}
+
+/// リンク先を `{ scene_id, step_index }` に解決する。
+/// check_path を通過済み（broken-link なし）という前提でのみ呼ばれる
+fn resolve_target(
+    scenes: &[LoadedScene],
+    scene_ids: &[String],
+    layouts: &[Vec<usize>],
+    current: usize,
+    target: &LinkTarget,
+) -> StepTarget {
+    let scene_idx = match &target.file {
+        None => current,
+        Some(file) => {
+            let canon = resolve_sibling(&scenes[current].path, file)
+                .and_then(|p| p.canonicalize().ok())
+                .expect("check済みのリンク先ファイルは解決できる");
+            scenes
+                .iter()
+                .position(|s| s.canon == canon)
+                .expect("check済みのリンク先ファイルは読み込み済み")
+        }
+    };
+    let step_index = match &target.anchor {
+        None => 0,
+        Some(anchor) => {
+            let section_idx = scenes[scene_idx]
+                .parsed
+                .scene
+                .sections
+                .iter()
+                .position(|s| s.anchor == *anchor)
+                .expect("check済みのアンカーは解決できる");
+            layouts[scene_idx][section_idx + 1]
+        }
+    };
+    StepTarget {
+        scene_id: scene_ids[scene_idx].clone(),
+        step_index,
+    }
+}
+
+// -------------------------------------------------------------- story_build_id
+
+/// bundle の内容（`story_build_id` を除く）から決定的に ID を計算する。
+/// ビルド時刻や乱数を使わないため、同じ入力からは常に同じ ID になり、
+/// Golden JSON 比較や arikoi 側のキャッシュ判定に使える
+fn compute_build_id(bundle: &StoryBundle) -> String {
+    let payload = serde_json::json!({
+        "schemaVersion": bundle.schema_version,
+        "title": bundle.title,
+        "entrySceneId": bundle.entry_scene_id,
+        "scenes": bundle.scenes,
+        "assets": bundle.assets,
+    });
+    let bytes = serde_json::to_vec(&payload).expect("シリアライズに失敗しない");
+    format!("{:016x}", fnv1a64(&bytes))
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}

--- a/src/scenario/mod.rs
+++ b/src/scenario/mod.rs
@@ -25,6 +25,7 @@
 mod anchor;
 mod characters;
 mod check;
+mod compile;
 mod diagnostic;
 mod exec;
 mod fmt;
@@ -39,6 +40,10 @@ mod trace;
 pub use anchor::{percent_decode, slugify};
 pub use characters::{Characters, find_characters_file, load_characters};
 pub use check::{CheckOptions, CheckResult, check_path};
+pub use compile::{
+    BundleAsset, BundleScene, BundleStep, ChoiceOption as BundleChoiceOption, CompileOptions,
+    CompileResult, SourceLocation, StepTarget, StoryBundle, compile_path,
+};
 pub use diagnostic::{Diagnostic, Severity, Span};
 pub use fmt::{FmtChange, FmtResult, fmt_path, fmt_str};
 pub use parse::{FrontMatterSpans, Parsed, parse_file, parse_str};

--- a/tests/compile_test.rs
+++ b/tests/compile_test.rs
@@ -1,0 +1,213 @@
+//! `scenario::compile_path`（#128）の統合テスト
+//!
+//! StoryBundle JSON 生成の仕様を検証する。examples/spring を全ブロック種別
+//! （narration / dialogue / choice / jump / ending）を含む正常系サンプルとして
+//! 使い、tests/fixtures/ 配下の check 用フィクスチャを失敗系に流用する。
+
+use std::path::Path;
+use tsumugai::scenario::{BundleAsset, BundleStep, CompileOptions, StepTarget, compile_path};
+
+fn spring() -> &'static Path {
+    Path::new("examples/spring/scenario/spring_001.md")
+}
+
+// -------------------------------------------------------------- 正常系
+
+#[test]
+fn spring例からstorybundleを生成できる() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    assert!(!result.has_errors());
+    let bundle = result
+        .bundle
+        .as_ref()
+        .expect("check が通れば bundle が返る");
+
+    assert_eq!(bundle.schema_version, "1");
+    assert_eq!(bundle.entry_scene_id, "spring_001");
+    assert_eq!(bundle.title, "春・出会い");
+    assert!(!bundle.story_build_id.is_empty());
+
+    let mut scene_ids: Vec<&str> = bundle.scenes.iter().map(|s| s.id.as_str()).collect();
+    scene_ids.sort();
+    assert_eq!(scene_ids, vec!["spring_001", "spring_002"]);
+}
+
+#[test]
+fn 全ブロック種別がstepに変換される() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+    let spring_001 = bundle
+        .scenes
+        .iter()
+        .find(|s| s.id == "spring_001")
+        .expect("spring_001 が bundle に含まれる");
+
+    assert_eq!(spring_001.steps.len(), 11);
+    assert!(
+        spring_001
+            .steps
+            .iter()
+            .any(|s| matches!(s, BundleStep::Narration { .. }))
+    );
+    assert!(
+        spring_001
+            .steps
+            .iter()
+            .any(|s| matches!(s, BundleStep::Dialogue { .. }))
+    );
+    assert!(
+        spring_001
+            .steps
+            .iter()
+            .any(|s| matches!(s, BundleStep::Choice { .. }))
+    );
+    assert!(
+        spring_001
+            .steps
+            .iter()
+            .any(|s| matches!(s, BundleStep::Jump { .. }))
+    );
+    assert!(
+        spring_001
+            .steps
+            .iter()
+            .any(|s| matches!(s, BundleStep::Ending { .. }))
+    );
+}
+
+#[test]
+fn ファイルをまたぐジャンプはscene_idとstep_indexに解決される() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+    let spring_001 = bundle.scenes.iter().find(|s| s.id == "spring_001").unwrap();
+    let spring_002 = bundle.scenes.iter().find(|s| s.id == "spring_002").unwrap();
+
+    let jump_target = spring_001
+        .steps
+        .iter()
+        .find_map(|s| match s {
+            BundleStep::Jump { target, .. } if target.scene_id == "spring_002" => Some(target),
+            _ => None,
+        })
+        .expect("spring_002 への jump がある（walk-together → after-school）");
+
+    assert_eq!(
+        jump_target,
+        &StepTarget {
+            scene_id: "spring_002".to_string(),
+            step_index: 8,
+        }
+    );
+    // after-school セクションの最初のステップは Dialogue
+    assert!(matches!(
+        spring_002.steps[jump_target.step_index],
+        BundleStep::Dialogue { .. }
+    ));
+}
+
+#[test]
+fn 同一ファイル内の選択肢は自身のscene_idとstep_indexに解決される() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+    let spring_001 = bundle.scenes.iter().find(|s| s.id == "spring_001").unwrap();
+
+    let choice_items = spring_001
+        .steps
+        .iter()
+        .find_map(|s| match s {
+            BundleStep::Choice { items, .. } => Some(items),
+            _ => None,
+        })
+        .expect("選択肢ステップがある");
+    assert_eq!(choice_items.len(), 3);
+
+    let run_together = choice_items
+        .iter()
+        .find(|i| i.label == "一緒に走る")
+        .unwrap();
+    assert_eq!(run_together.target.scene_id, "spring_001");
+    assert!(matches!(
+        spring_001.steps[run_together.target.step_index],
+        BundleStep::Dialogue { .. }
+    ));
+
+    let leave_first = choice_items
+        .iter()
+        .find(|i| i.label == "先に行ってもらう")
+        .unwrap();
+    assert_eq!(leave_first.target.scene_id, "spring_002");
+    assert_eq!(leave_first.target.step_index, 0);
+}
+
+#[test]
+fn assetはファイル横断で重複排除して収集される() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+
+    assert_eq!(bundle.assets.len(), 3);
+    assert!(bundle.assets.contains(&BundleAsset::Background {
+        path: "../assets/bg/school_gate.png".to_string()
+    }));
+    assert!(bundle.assets.contains(&BundleAsset::Background {
+        path: "../assets/bg/classroom.png".to_string()
+    }));
+    assert!(bundle.assets.contains(&BundleAsset::Bgm {
+        path: "../assets/bgm/spring.ogg".to_string()
+    }));
+}
+
+#[test]
+fn 同じ入力からは同じstory_build_idが生成される() {
+    let a = compile_path(spring(), &CompileOptions::default());
+    let b = compile_path(spring(), &CompileOptions::default());
+    assert_eq!(
+        a.bundle.unwrap().story_build_id,
+        b.bundle.unwrap().story_build_id
+    );
+}
+
+// -------------------------------------------------------------- 異常系
+
+#[test]
+fn checkエラーがあるとbundleを生成せず診断を返す() {
+    let result = compile_path(
+        Path::new("tests/fixtures/trace/broken/scenario.md"),
+        &CompileOptions::default(),
+    );
+
+    assert!(result.check.has_errors());
+    assert!(result.bundle.is_none());
+    assert!(result.has_errors());
+}
+
+#[test]
+fn 存在しないassetがあるとbundleを生成しない() {
+    let result = compile_path(
+        Path::new("tests/fixtures/check/missing_asset/scene.md"),
+        &CompileOptions::default(),
+    );
+
+    assert!(result.check.has_errors());
+    assert!(result.bundle.is_none());
+    assert!(
+        result
+            .check
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_id == "missing-asset")
+    );
+}
+
+#[test]
+fn ディレクトリを渡すとio_errorになる() {
+    let result = compile_path(Path::new("examples/spring"), &CompileOptions::default());
+    assert!(result.check.has_errors());
+    assert!(result.bundle.is_none());
+    assert!(
+        result
+            .check
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_id == "io-error")
+    );
+}


### PR DESCRIPTION
## Summary
- `tsumugai compile <file> --target web --output <path>` を実装し、Markdown シナリオから arikoi 側 Svelte player 向けの StoryBundle JSON を生成できるようにする
- `src/scenario/compile.rs`: `StoryBundle` / `BundleScene` / `BundleStep`（narration/dialogue/choice/jump/ending の5種） / `BundleAsset` を定義し、`compile_path()` で構築する
  - jump/choice の飛び先は `{ sceneId, stepIndex }` に解決済みで持たせる（ソース表記のまま持たない）
  - `storyBuildId` はビルド時刻・乱数を使わず bundle 内容から決定的に計算（FNV-1a）。同じ入力からは常に同じ ID になり、Golden JSON 比較や arikoi 側のキャッシュ判定に使える
  - 実行前検査（check 相当）で error があれば出力ファイルを書き出さず失敗する
  - 現行 v1 記法には変数構文が無いため `set_variable` は未実装（コード内にその旨を明記）
- README.md / docs/API.md / CLAUDE.md / AGENTS.md を実装済みの状態に更新

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`（tests/compile_test.rs の9テストを含む全テスト・doctest green）
- [x] `cargo run -- compile examples/spring/scenario/spring_001.md --target web --output /tmp/story-bundle.json` で正常系のJSON出力を目視確認
- [x] `cargo run -- compile tests/fixtures/check/missing_asset/scene.md --target web --output ...` でexit 1・ファイル未生成を確認

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)