### PR TITLE
test/ci: compileのGolden JSON・エラーケーステストとCI組み込み

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,6 @@ jobs:
 
     - name: Tests
       run: cargo test
+
+    - name: compile smoke test
+      run: cargo run -- compile examples/spring/scenario/spring_001.md --target web --output /tmp/story-bundle.json

--- a/tests/compile_test.rs
+++ b/tests/compile_test.rs
@@ -1,10 +1,17 @@
-//! `scenario::compile_path`（#128）の統合テスト
+//! `scenario::compile_path`（#128）と `tsumugai compile`（#135）の統合テスト
 //!
 //! StoryBundle JSON 生成の仕様を検証する。examples/spring を全ブロック種別
 //! （narration / dialogue / choice / jump / ending）を含む正常系サンプルとして
 //! 使い、tests/fixtures/ 配下の check 用フィクスチャを失敗系に流用する。
+//!
+//! Golden JSON（tests/fixtures/compile/golden/spring_001.json）と CLI
+//! プロセスを実際に起動するテストは #135 で追加した。前者は意図しない出力
+//! 変化を検出し、後者は「エラー時に出力ファイルを書き出さない」という
+//! main.rs 側の制御フローを、compile_path の戻り値だけでなく実際の
+//! ファイルシステムへの影響で確認する。
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use tsumugai::scenario::{BundleAsset, BundleStep, CompileOptions, StepTarget, compile_path};
 
 fn spring() -> &'static Path {
@@ -209,5 +216,163 @@ fn ディレクトリを渡すとio_errorになる() {
             .diagnostics
             .iter()
             .any(|d| d.rule_id == "io-error")
+    );
+}
+
+// -------------------------------------------------------------- choiceからendingまでのroute
+
+/// [`StepTarget`] だけを頼りに、選択肢ブロックで指定した項目を選びながら
+/// ending に到達するまで歩く。routes.rs 自身の探索アルゴリズム
+/// （Cursor / goto、パース結果の Scene を直接辿る）とは別に、
+/// **compile が出力する StoryBundle 単体で経路を再現できること**を確認する
+fn walk_to_ending(bundle: &tsumugai::scenario::StoryBundle, choose: &[&str]) -> String {
+    let mut scene_id = bundle.entry_scene_id.clone();
+    let mut step_index = 0usize;
+    let mut choose = choose.iter();
+    loop {
+        let scene = bundle
+            .scenes
+            .iter()
+            .find(|s| s.id == scene_id)
+            .unwrap_or_else(|| panic!("scene {scene_id} が bundle にある"));
+        match &scene.steps[step_index] {
+            BundleStep::Narration { .. } | BundleStep::Dialogue { .. } => step_index += 1,
+            BundleStep::Ending { id, .. } => return id.clone(),
+            BundleStep::Jump { target, .. } => {
+                scene_id = target.scene_id.clone();
+                step_index = target.step_index;
+            }
+            BundleStep::Choice { items, .. } => {
+                let label = choose.next().expect("choose に選択肢の数だけラベルを渡す");
+                let item = items
+                    .iter()
+                    .find(|i| i.label == *label)
+                    .unwrap_or_else(|| panic!("選択肢「{label}」が見つかる"));
+                scene_id = item.target.scene_id.clone();
+                step_index = item.target.step_index;
+            }
+        }
+    }
+}
+
+#[test]
+fn choiceからendingまでの経路をbundle単体で再現できる() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+
+    assert_eq!(walk_to_ending(bundle, &["一緒に走る"]), "childhood_route");
+    assert_eq!(
+        walk_to_ending(bundle, &["先に行ってもらう", "休み時間に話しかける"]),
+        "sprint_route"
+    );
+    assert_eq!(
+        walk_to_ending(bundle, &["先に行ってもらう", "放課後まで待つ"]),
+        "calm_route"
+    );
+}
+
+// -------------------------------------------------------------- Golden JSON
+
+fn golden_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/compile/golden/spring_001.json")
+}
+
+#[test]
+fn spring例のstorybundleはgolden_jsonと一致する() {
+    let result = compile_path(spring(), &CompileOptions::default());
+    let bundle = result.bundle.as_ref().unwrap();
+    let actual: serde_json::Value = serde_json::to_value(bundle).unwrap();
+
+    let golden_text = std::fs::read_to_string(golden_fixture()).expect(
+        "tests/fixtures/compile/golden/spring_001.json が読める（先に生成してコミットする）",
+    );
+    let expected: serde_json::Value = serde_json::from_str(&golden_text).unwrap();
+
+    assert_eq!(
+        actual, expected,
+        "StoryBundle の出力が変化した。意図した変更なら tests/fixtures/compile/golden/spring_001.json を更新すること"
+    );
+}
+
+// -------------------------------------------------------------- CLIプロセス経由の確認
+
+fn unique_output_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "tsumugai-compile-test-{}-{}.json",
+        name,
+        std::process::id()
+    ))
+}
+
+fn run_compile(scenario: &str, output: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_tsumugai"))
+        .args([
+            "compile",
+            scenario,
+            "--target",
+            "web",
+            "--output",
+            output.to_str().unwrap(),
+        ])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("tsumugai バイナリを起動できる")
+}
+
+#[test]
+fn cli正常系はgolden_jsonと同じ内容のファイルを書き出す() {
+    let output = unique_output_path("success");
+    let _ = std::fs::remove_file(&output);
+
+    let result = run_compile("examples/spring/scenario/spring_001.md", &output);
+    assert!(
+        result.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&output).expect("出力ファイルができる"))
+            .unwrap();
+    let golden: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(golden_fixture()).unwrap()).unwrap();
+    assert_eq!(written, golden);
+
+    let _ = std::fs::remove_file(&output);
+}
+
+#[test]
+fn cliで不正なjump先があると出力ファイルを生成せず失敗する() {
+    let output = unique_output_path("broken-jump");
+    let _ = std::fs::remove_file(&output);
+
+    let result = run_compile("tests/fixtures/trace/broken/scenario.md", &output);
+    assert!(!result.status.success());
+    assert!(
+        !output.exists(),
+        "check エラー時は出力ファイルを書き出さない"
+    );
+    assert!(
+        String::from_utf8_lossy(&result.stdout).contains("broken-link"),
+        "stdout: {}",
+        String::from_utf8_lossy(&result.stdout)
+    );
+}
+
+#[test]
+fn cliで存在しないasset参照があると出力ファイルを生成せず失敗する() {
+    let output = unique_output_path("missing-asset");
+    let _ = std::fs::remove_file(&output);
+
+    let result = run_compile("tests/fixtures/check/missing_asset/scene.md", &output);
+    assert!(!result.status.success());
+    assert!(
+        !output.exists(),
+        "check エラー時は出力ファイルを書き出さない"
+    );
+    assert!(
+        String::from_utf8_lossy(&result.stdout).contains("missing-asset"),
+        "stdout: {}",
+        String::from_utf8_lossy(&result.stdout)
     );
 }

--- a/tests/fixtures/compile/golden/spring_001.json
+++ b/tests/fixtures/compile/golden/spring_001.json
@@ -1,0 +1,292 @@
+{
+  "schemaVersion": "1",
+  "storyBuildId": "157a3791c1e0a291",
+  "title": "春・出会い",
+  "entrySceneId": "spring_001",
+  "scenes": [
+    {
+      "id": "spring_001",
+      "title": "春・出会い",
+      "source": {
+        "file": "examples/spring/scenario/spring_001.md",
+        "line": 1
+      },
+      "steps": [
+        {
+          "type": "narration",
+          "text": "桜の花びらが舞う通学路。いつもと同じ朝のはずだった。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 9
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "幼なじみ",
+          "text": "おはよう。今日も遅刻しそうだね。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 11
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "まだ間に合うよ。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 13
+          }
+        },
+        {
+          "type": "narration",
+          "text": "校門までは、あと五百メートル。始業のチャイムまで、あと三分。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 15
+          }
+        },
+        {
+          "type": "choice",
+          "items": [
+            {
+              "label": "一緒に走る",
+              "target": {
+                "sceneId": "spring_001",
+                "stepIndex": 5
+              },
+              "source": {
+                "file": "examples/spring/scenario/spring_001.md",
+                "line": 19
+              }
+            },
+            {
+              "label": "諦めて歩く",
+              "target": {
+                "sceneId": "spring_001",
+                "stepIndex": 8
+              },
+              "source": {
+                "file": "examples/spring/scenario/spring_001.md",
+                "line": 20
+              }
+            },
+            {
+              "label": "先に行ってもらう",
+              "target": {
+                "sceneId": "spring_002",
+                "stepIndex": 0
+              },
+              "source": {
+                "file": "examples/spring/scenario/spring_001.md",
+                "line": 21
+              }
+            }
+          ],
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 19
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "幼なじみ",
+          "text": "ほら、急ぐよ！",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 25
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "待ってってば！",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 27
+          }
+        },
+        {
+          "type": "ending",
+          "id": "childhood_route",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 29
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "もう間に合わないし、歩こうよ。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 33
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "幼なじみ",
+          "text": "……たまには、そういうのもいいか。",
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 35
+          }
+        },
+        {
+          "type": "jump",
+          "target": {
+            "sceneId": "spring_002",
+            "stepIndex": 8
+          },
+          "source": {
+            "file": "examples/spring/scenario/spring_001.md",
+            "line": 37
+          }
+        }
+      ]
+    },
+    {
+      "id": "spring_002",
+      "title": "翌朝",
+      "source": {
+        "file": "examples/spring/scenario/spring_002.md",
+        "line": 1
+      },
+      "steps": [
+        {
+          "type": "narration",
+          "text": "結局、彼女は先に行ってしまった。教室に着いたのは、チャイムが鳴り終わったあとだった。",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 8
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "（昨日はちゃんと謝れなかったな……）",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 10
+          }
+        },
+        {
+          "type": "choice",
+          "items": [
+            {
+              "label": "休み時間に話しかける",
+              "target": {
+                "sceneId": "spring_002",
+                "stepIndex": 3
+              },
+              "source": {
+                "file": "examples/spring/scenario/spring_002.md",
+                "line": 14
+              }
+            },
+            {
+              "label": "放課後まで待つ",
+              "target": {
+                "sceneId": "spring_002",
+                "stepIndex": 6
+              },
+              "source": {
+                "file": "examples/spring/scenario/spring_002.md",
+                "line": 15
+              }
+            }
+          ],
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 14
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "あのさ、昨日は──",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 19
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "幼なじみ",
+          "text": "いいよ、別に。ほら、次、移動教室。",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 21
+          }
+        },
+        {
+          "type": "ending",
+          "id": "sprint_route",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 23
+          }
+        },
+        {
+          "type": "narration",
+          "text": "話しかけるタイミングを逃したまま、授業だけが過ぎていく。",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 27
+          }
+        },
+        {
+          "type": "jump",
+          "target": {
+            "sceneId": "spring_002",
+            "stepIndex": 8
+          },
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 29
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "幼なじみ",
+          "text": "……で、いつまでそこに突っ立ってるの？",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 33
+          }
+        },
+        {
+          "type": "dialogue",
+          "speaker": "主人公",
+          "text": "昨日のこと、謝ろうと思って。",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 35
+          }
+        },
+        {
+          "type": "ending",
+          "id": "calm_route",
+          "source": {
+            "file": "examples/spring/scenario/spring_002.md",
+            "line": 37
+          }
+        }
+      ]
+    }
+  ],
+  "assets": [
+    {
+      "kind": "background",
+      "path": "../assets/bg/classroom.png"
+    },
+    {
+      "kind": "background",
+      "path": "../assets/bg/school_gate.png"
+    },
+    {
+      "kind": "bgm",
+      "path": "../assets/bgm/spring.ogg"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- #135: compile の Golden JSON テスト・エラーケーステストを整備
  - `tests/fixtures/compile/golden/spring_001.json` をコミットし、examples/spring の出力と意味的に一致することを確認するテストを追加（`storyBuildId` を内容ベースの決定的な値にしていたため乱数・時刻に左右されない）
  - `CARGO_BIN_EXE_tsumugai` でCLIを実際に起動し、正常系（Golden一致）／不正なjump先／存在しないasset参照のそれぞれで、期待通りの exit code と「出力ファイルを生成しない」ことを確認
  - choiceからendingまでの経路を StoryBundle の `stepIndex` だけを辿って再現するテストを追加（routes.rs 自身の探索アルゴリズムとは別に、compile 出力単体で経路が再現できることを確認）
- #136: `.github/workflows/ci.yml` に compile のスモークテストステップを追加
  - `examples/acceptance` は存在しないため、既存の仕様網羅サンプル `examples/spring/scenario/spring_001.md` を使用
  - 異常系の失敗確認は #135 で追加した cargo test 側の CLI プロセステストでカバー済みのため、CI には成功系のみ追加

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`（tests/compile_test.rs が9件→14件に増加、全テスト・doctest green）
- [x] ローカルで CI と同じ compile スモークコマンドを実行し、StoryBundle JSON が生成されることを確認

Closes #135
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)