### PR TITLE
test: tsumugai CLIの外部結合レベルの統合テストを追加する

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,8 @@ tsumugai/
 │     ├─ diagnostic.rs   # 構造化 Diagnostic（rule_id / severity / message / span / suggestion）
 │     └─ report.rs       # human / JSON / SARIF 出力
 ├─ tests/
-│  ├─ check_test.rs / trace_test.rs / routes_test.rs / compile_test.rs  # 統合テスト
+│  ├─ check_test.rs / trace_test.rs / routes_test.rs / compile_test.rs  # 統合テスト（ライブラリ関数を直接呼ぶ）
+│  ├─ cli_test.rs                                                      # 外部結合レベルのCLIプロセステスト（check/trace/routes/fmt）
 │  └─ fixtures/                                                        # ケースごとのミニプロジェクト・Golden JSON
 ├─ examples/
 │  ├─ spring/            # 全ブロック種別を含む仕様網羅サンプル
@@ -78,9 +79,9 @@ tsumugai/
 
 ## 5. テスト戦略
 
-- **統合テスト**（`tests/*.rs`）: ライブラリ関数（`check_path` 等）を直接呼び出し、`tests/fixtures/` 配下のミニプロジェクトで各ルールを 1 対 1 で検証する
+- **統合テスト**（`check_test.rs` 等）: ライブラリ関数（`check_path` 等）を直接呼び出し、`tests/fixtures/` 配下のミニプロジェクトで各ルールを 1 対 1 で検証する。`main.rs` の引数パース・exit code・ファイル I/O は経由しない
 - **Golden JSON**（`tests/fixtures/compile/golden/*.json` 等）: 意図しない出力変化を検出する
-- **CLI プロセステスト**（`compile_test.rs`）: `CARGO_BIN_EXE_tsumugai` で実バイナリを起動し、exit code とファイル生成有無を確認する
+- **外部結合レベルの CLI プロセステスト**（`cli_test.rs` / `compile_test.rs`）: `CARGO_BIN_EXE_tsumugai` で実バイナリを起動し、tsumugai を外部ツールとして使う消費者（CI・arikoi 等）が実際に観測する exit code・stdout（human / JSON / SARIF）・ファイル生成有無（`compile --output` / `fmt --write`）をブラックボックスに確認する
 - **doctest**: `src/scenario/mod.rs` / `src/lib.rs` のコード例を `cargo test` で検証する
 
 CLI 引数パース自体（`main.rs`）は薄く保ち、原則としてテストしない。ロジックは `scenario` モジュールの関数に置き、そちらをテスト対象にする。

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,193 @@
+//! tsumugai CLI バイナリの外部結合レベルの統合テスト
+//!
+//! check_test.rs / trace_test.rs / routes_test.rs は `scenario::check_path` 等の
+//! ライブラリ関数を直接呼び出しており、`main.rs` の引数パース・exit code・
+//! stdout 整形・ファイル I/O（`fmt --write`）は経由しない。
+//!
+//! tsumugai は外部ツールとして CLI サブプロセス + JSON（stdout / `compile
+//! --output`）で消費される契約（docs/ARCHITECTURE.md 8章）なので、ここでは
+//! 実バイナリを `CARGO_BIN_EXE_tsumugai` で起動し、check / trace / routes /
+//! fmt の 4 コマンドについてその契約をブラックボックスに検証する。
+//! `compile` の同種のテストは tests/compile_test.rs にある。
+
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_tsumugai"))
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("tsumugai バイナリを起動できる")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+// ---------------------------------------------------------------------- check
+
+#[test]
+fn check_examplesはexit0で問題なしと表示する() {
+    let out = run(&["check", "examples/spring"]);
+    assert!(out.status.success(), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).contains("問題は見つかりませんでした"));
+}
+
+#[test]
+fn check_jsonはexit0でstatus_okの有効なjsonを返す() {
+    let out = run(&["check", "examples/spring", "--format", "json"]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["files"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn check_sarifは有効なsarif_2_1_0を返す() {
+    let out = run(&["check", "examples/spring", "--format", "sarif"]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert_eq!(json["version"], "2.1.0");
+    assert!(json["runs"].is_array());
+}
+
+#[test]
+fn checkでbroken_linkがあるとexit1になりファイル出力はしない() {
+    let out = run(&["check", "tests/fixtures/trace/broken/scenario.md"]);
+    assert!(!out.status.success());
+    assert!(stdout(&out).contains("broken-link"));
+}
+
+#[test]
+fn checkで存在しないパスはexit1でio_errorになる() {
+    let out = run(&["check", "no/such/path.md"]);
+    assert!(!out.status.success());
+    assert!(stdout(&out).contains("io-error"));
+}
+
+// ---------------------------------------------------------------------- trace
+
+#[test]
+fn trace_choices無しは選択肢の入力待ちで停止しexit0() {
+    let out = run(&["trace", "examples/spring/scenario/spring_001.md"]);
+    assert!(out.status.success(), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).contains("入力待ちで停止しました"));
+}
+
+#[test]
+fn trace_choicesを与えるとendingに到達しexit0() {
+    let out = run(&[
+        "trace",
+        "examples/spring/scenario/spring_001.md",
+        "--choices",
+        "1",
+    ]);
+    assert!(out.status.success(), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).contains("childhood_route"));
+}
+
+#[test]
+fn trace_jsonは有効なjsonを返す() {
+    let out = run(&[
+        "trace",
+        "examples/spring/scenario/spring_001.md",
+        "--choices",
+        "1",
+        "--format",
+        "json",
+    ]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert_eq!(json["status"], "ok");
+}
+
+#[test]
+fn trace_範囲外の選択番号はexit1になる() {
+    let out = run(&[
+        "trace",
+        "examples/spring/scenario/spring_001.md",
+        "--choices",
+        "99",
+    ]);
+    assert!(!out.status.success());
+    assert!(stdout(&out).contains("選択番号 99"));
+}
+
+// --------------------------------------------------------------------- routes
+
+#[test]
+fn routesは全経路を探索しexit0で報告する() {
+    let out = run(&["routes", "examples/spring/scenario/spring_001.md"]);
+    assert!(out.status.success(), "stdout: {}", stdout(&out));
+    assert!(stdout(&out).contains("発見した経路数: 4"));
+}
+
+#[test]
+fn routes_jsonは有効なjsonを返す() {
+    let out = run(&[
+        "routes",
+        "examples/spring/scenario/spring_001.md",
+        "--format",
+        "json",
+    ]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stdout(&out)).unwrap();
+    assert_eq!(json["status"], "ok");
+}
+
+#[test]
+fn routesで循環があるとexit1になる() {
+    let out = run(&["routes", "tests/fixtures/trace/loop/scenario.md"]);
+    assert!(!out.status.success());
+    assert!(stdout(&out).contains("circular-route"));
+}
+
+// ------------------------------------------------------------------------ fmt
+
+#[test]
+fn fmt_writeなしでは入力ファイルを変更しない() {
+    let before = std::fs::read_to_string("examples/fmt/before.md").unwrap();
+
+    // [SHOW_IMAGE ...] が legacy-command の error になるため exit 1 だが、
+    // --write を付けない限りファイルには一切触れない
+    let out = run(&["fmt", "examples/fmt/before.md"]);
+    assert!(!out.status.success());
+
+    let after_run = std::fs::read_to_string("examples/fmt/before.md").unwrap();
+    assert_eq!(
+        before, after_run,
+        "--write なしでは入力ファイルを変更しない"
+    );
+}
+
+#[test]
+fn fmt_writeで整形結果がafter_mdと一致する() {
+    // fmt --write は入力ファイルへ直接書き戻すため、リポジトリのサンプルを
+    // 汚さないよう一時ディレクトリにコピーしてから実行する。
+    // fmt-paren-dialogue の判定には同階層の characters.yaml が要るため、
+    // before.md と一緒にコピーする
+    let dir = std::env::temp_dir().join(format!(
+        "tsumugai-cli-test-fmt-write-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("一時ディレクトリを作成できる");
+    let target = dir.join("before.md");
+    std::fs::copy("examples/fmt/before.md", &target).unwrap();
+    std::fs::copy("examples/fmt/characters.yaml", dir.join("characters.yaml")).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_tsumugai"))
+        .args(["fmt", target.to_str().unwrap(), "--write"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("tsumugai バイナリを起動できる");
+
+    // legacy-command の error は変換できないため残り、exit code は 1 のまま。
+    // ただし --write の書き戻し自体は変更可能な箇所に対して行われる
+    assert!(!out.status.success());
+
+    let written = std::fs::read_to_string(&target).expect("書き戻されたファイルを読める");
+    let expected = std::fs::read_to_string("examples/fmt/after.md").unwrap();
+    assert_eq!(written, expected);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
既存の `check_test.rs` / `trace_test.rs` / `routes_test.rs` は `scenario::check_path` 等のライブラリ関数を直接呼び出すのみで、`main.rs` の引数パース・exit code・stdout整形・ファイルI/O（`fmt --write`）を経由していなかった。tsumugai は外部ツールとして CLI サブプロセス + JSON（stdout / `compile --output`）で消費される契約（docs/ARCHITECTURE.md 8章）なので、その契約自体をブラックボックスに検証するテストを追加する。

- `tests/cli_test.rs`（新規、14テスト）: `CARGO_BIN_EXE_tsumugai` で実バイナリを起動し、`check` / `trace` / `routes` / `fmt` の4コマンドを検証
  - `check`: 成功時のhuman表示、`--format json/sarif` の妥当性、broken-link・存在しないパスでの exit 1
  - `trace`: `--choices` 無しでの入力待ち停止、ending への到達、`--format json`、範囲外選択番号での exit 1
  - `routes`: 全経路探索の成功表示、`--format json`、循環での exit 1
  - `fmt`: `--write` 無しでは入力ファイルを変更しないこと、`--write` で `examples/fmt/after.md` と一致する内容に書き換わること（リポジトリのサンプルを汚さないよう一時ディレクトリにコピーして実行）
- `compile` の同種テストは既存の `tests/compile_test.rs` でカバー済みのため対象外（重複回避）
- `docs/ARCHITECTURE.md` のテスト戦略・ディレクトリ構成に `tests/cli_test.rs` を追記

各アサーションの文言・exit codeは実バイナリを事前に手動実行して確認済み（推測で書いていない）。

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`（cli_test.rs の14テストを含む全テスト・doctest green）
- [x] `fmt --write` テスト実行後、`git status` でリポジトリの実ファイル（examples/fmt/before.md 等）に変更がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)