### PR TITLE
Diagnostic/SourceLocationにcolumn情報を追加する

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -47,7 +47,7 @@ pub struct Diagnostic {
     pub severity: Severity,      // Error | Warning
     pub message: String,
     pub file: PathBuf,
-    pub span: Option<Span>,          // { line: usize }
+    pub span: Option<Span>,          // { line: usize, column: Option<usize> }
     pub related_spans: Vec<Span>,
     pub suggestion: Option<String>,  // 機械的に適用できる書き換え例
 }

--- a/docs/CLI_OUTPUT.md
+++ b/docs/CLI_OUTPUT.md
@@ -68,6 +68,7 @@ error[broken-link]: このファイルに「run-togather」という見出し（
 - `severity[rule_id]: メッセージ` → 位置（`--> ファイル:行`）→ 入力行の引用 → `= help:`（機械的に適用できる書き換え例）→ `= note:`（関連する行）
 - 最初のエラーで止まらず、検出できたすべての Diagnostic をまとめて報告する
 - 終了コード: エラーあり → **1**、警告のみ → **0**
+- 列位置（`span.column`）が分かる場合は `--> ファイル:行:列` になり、入力行の下に caret（`^`）が1つ表示される。現時点ではどのルールも列位置を計算しておらず常に `null`（#150、段階導入中）
 
 ---
 
@@ -85,8 +86,8 @@ error[broken-link]: このファイルに「run-togather」という見出し（
       "severity": "error",
       "message": "このファイルに「run-togather」という見出し（##）はありません。よく似た「## run-together」があります。`[一緒に走る](#run-together)` の間違いではありませんか？",
       "file": "scenario/spring_001.md",
-      "span": { "line": 9 },
-      "related_spans": [{ "line": 13 }],
+      "span": { "line": 9, "column": null },
+      "related_spans": [{ "line": 13, "column": null }],
       "suggestion": "[一緒に走る](#run-together)"
     }
   ]
@@ -107,8 +108,8 @@ error[broken-link]: このファイルに「run-togather」という見出し（
       "severity": "error" | "warning",
       "message": string,
       "file": string,
-      "span": { "line": number } | null,
-      "related_spans": [{ "line": number }],
+      "span": { "line": number, "column": number | null } | null,
+      "related_spans": [{ "line": number, "column": number | null }],
       "suggestion": string | null
     }
   ]

--- a/docs/DIAGNOSTIC.md
+++ b/docs/DIAGNOSTIC.md
@@ -30,9 +30,12 @@ pub struct Diagnostic {
 }
 
 pub struct Span {
-    pub line: usize,    // 1-origin
+    pub line: usize,           // 1-origin
+    pub column: Option<usize>, // 1-origin。分かる場合のみ Some（#150）
 }
 ```
+
+`column` は現時点では型定義のみの段階導入で、どのルールも値を埋めていない（常に `None`）。`Diagnostic::with_column` で付与すると、`render_human` が `file:line:column` 表示と入力行の下に caret（`^`）を1つ表示する。broken-link・undefined-character 等、リンクや話者名の位置を指すルールから順に列位置の計算を追加していく方針（段階導入、SPEC.md参照なし・issue #150参照）。
 
 ---
 

--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -195,7 +195,7 @@ check の JSON（[CLI_OUTPUT.md](CLI_OUTPUT.md)）の上位互換。`file`（開
       "severity": "error",
       "message": "このファイルに「run-togather」という見出し（##）はありません。…",
       "file": "scenario/spring_001.md",
-      "span": { "line": 19 },
+      "span": { "line": 19, "column": null },
       "related_spans": [],
       "suggestion": "[一緒に走る](#run-together)"
     }

--- a/src/scenario/check.rs
+++ b/src/scenario/check.rs
@@ -292,7 +292,10 @@ fn check_one_link(
         ));
         diag.suggestion = Some(format!("[{label}]({fixed})"));
         if target.file.is_none() {
-            diag.related_spans.push(Span { line: section.line });
+            diag.related_spans.push(Span {
+                line: section.line,
+                column: None,
+            });
         }
     } else if anchors.is_empty() {
         diag.message.push_str(
@@ -512,7 +515,11 @@ fn check_speakers(scene: &LoadedScene, chars: &Characters, diagnostics: &mut Vec
         let mut diag =
             Diagnostic::warning("undefined-character", &scene.path, occ.first_line, message);
         diag.suggestion = suggestion;
-        diag.related_spans = occ.rest.into_iter().map(|line| Span { line }).collect();
+        diag.related_spans = occ
+            .rest
+            .into_iter()
+            .map(|line| Span { line, column: None })
+            .collect();
         diagnostics.push(diag);
     }
 }

--- a/src/scenario/diagnostic.rs
+++ b/src/scenario/diagnostic.rs
@@ -22,6 +22,8 @@ pub enum Severity {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Span {
     pub line: usize,
+    /// 列位置（1-origin）。分かる場合のみ Some（#150）
+    pub column: Option<usize>,
 }
 
 /// 検出した 1 件の問題
@@ -50,7 +52,7 @@ impl Diagnostic {
             severity: Severity::Error,
             message,
             file: file.to_path_buf(),
-            span: Some(Span { line }),
+            span: Some(Span { line, column: None }),
             related_spans: Vec::new(),
             suggestion: None,
         }
@@ -74,7 +76,15 @@ impl Diagnostic {
     }
 
     pub fn with_related(mut self, line: usize) -> Self {
-        self.related_spans.push(Span { line });
+        self.related_spans.push(Span { line, column: None });
+        self
+    }
+
+    /// 主 span に列位置（1-origin）を付与する（#150）
+    pub fn with_column(mut self, column: usize) -> Self {
+        if let Some(span) = &mut self.span {
+            span.column = Some(column);
+        }
         self
     }
 }

--- a/src/scenario/parse.rs
+++ b/src/scenario/parse.rs
@@ -401,7 +401,7 @@ impl<'a> SceneParser<'a> {
                         ),
                     )
                     .related_spans
-                    .push(super::Span { line: first });
+                    .push(super::Span { line: first, column: None });
                 } else if !self.scene.lead.is_empty() || !self.scene.sections.is_empty() {
                     self.error(
                         "invalid-h1",
@@ -445,7 +445,7 @@ impl<'a> SceneParser<'a> {
                         ),
                     )
                     .related_spans
-                    .push(super::Span { line: prev });
+                    .push(super::Span { line: prev, column: None });
                 }
                 self.current_section = Some(Section {
                     heading: text,

--- a/src/scenario/report.rs
+++ b/src/scenario/report.rs
@@ -63,13 +63,26 @@ fn render_one(
     };
 
     let width = span.line.to_string().len().max(2);
-    let _ = writeln!(
-        out,
-        "{:width$}--> {}:{}",
-        "",
-        diag.file.display(),
-        span.line
-    );
+    match span.column {
+        Some(col) => {
+            let _ = writeln!(
+                out,
+                "{:width$}--> {}:{}:{col}",
+                "",
+                diag.file.display(),
+                span.line
+            );
+        }
+        None => {
+            let _ = writeln!(
+                out,
+                "{:width$}--> {}:{}",
+                "",
+                diag.file.display(),
+                span.line
+            );
+        }
+    }
     let source_line = sources
         .entry(diag.file.clone())
         .or_insert_with(|| {
@@ -83,6 +96,10 @@ fn render_one(
     if let Some(text) = source_line {
         let _ = writeln!(out, "{:width$} |", "");
         let _ = writeln!(out, "{:width$} | {text}", span.line);
+        if let Some(col) = span.column {
+            let indent = " ".repeat(col.saturating_sub(1));
+            let _ = writeln!(out, "{:width$} | {indent}^", "");
+        }
         let _ = writeln!(out, "{:width$} |", "");
     }
     if let Some(suggestion) = &diag.suggestion {

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -8,7 +8,8 @@
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use tsumugai::scenario::{
-    CheckOptions, CheckResult, Severity, check_path, render_human, render_json, render_sarif,
+    CheckOptions, CheckResult, Diagnostic, Severity, check_path, render_human, render_json,
+    render_sarif,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -221,6 +222,46 @@ fn 人間向け出力はrustc風で位置と入力行と提案を示す() {
     );
     assert!(rendered.contains("= help: "), "{rendered}");
     assert!(rendered.contains("エラー: 1件  警告: 0件"), "{rendered}");
+}
+
+#[test]
+fn 列位置がわかる診断は人間向け出力でファイルパスにも列番号にもcaretにも反映される() {
+    // #150: Span/SourceLocationにcolumn情報を持たせ、要求文書のcaret付き診断例
+    // （file:line:column + ^ での位置表示）を再現できることを確認する
+    let path = fixture("typo_anchor/scene.md");
+    let diag =
+        Diagnostic::error("broken-link", &path, 9, "テスト用の診断".to_string()).with_column(11);
+    let result = CheckResult {
+        files: vec![path.clone()],
+        diagnostics: vec![diag],
+    };
+    let rendered = render_human(&result);
+
+    assert!(
+        rendered.contains(&format!("{}:9:11", path.display())),
+        "file:line:column の形式になる: {rendered}"
+    );
+    assert!(
+        rendered.contains("| - [一緒に走る](#run-togather)"),
+        "入力 Markdown の該当行を引用する: {rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("| {}^", " ".repeat(10))),
+        "column - 1 個の空白の後に caret が1つ表示される: {rendered}"
+    );
+}
+
+#[test]
+fn 列位置がない診断は人間向け出力にcaretもfile内の列番号も出さない() {
+    let rendered = render_human(&check("typo_anchor/scene.md"));
+    assert!(
+        !rendered.contains(":9:"),
+        "column が無ければ line の後に : が続かない: {rendered}"
+    );
+    assert!(
+        !rendered.contains('^'),
+        "column が無ければ caret を出さない: {rendered}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
#150 の受け入れ条件（最小スコープ: 型定義の追加 + human出力でのcaret表示対応）に対応した。

- `Span` に `column: Option<usize>` を追加（1-origin、分かる場合のみ `Some`）
- `Diagnostic::with_column(column)` builder を追加。主 span に列位置を付与する
- `render_human` は `span.column` が `Some` のとき `--> file:line:column` 表示にし、入力行の引用の下に caret（`^`）を1つ表示する。`None` のときは従来どおり（回帰なし）
- JSON出力は新フィールド追加のみで既存スキーマを壊さない（`"column": null` が増えるだけ）
- `docs/DIAGNOSTIC.md` / `docs/CLI_OUTPUT.md` / `docs/TRACE.md` / `docs/API.md` を実装に合わせて更新

## スコープ外（段階導入、issue継続）
issueの方針どおり、今回はどのルール（broken-link等）も実際の列位置を計算していない。既存の全Diagnosticは`column: None`のまま。各ルールへの列位置計算の追加は別途段階的に対応する。

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`（`tests/check_test.rs`にcaret表示の新規テスト2件を追加、全テストパス）
- [x] `cargo run -- check ... --format json` で `column: null` が新規フィールドとして追加されるだけであることを手動確認

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)