### PR TITLE
docs: AGENTS.mdをCLAUDE.md参照形式に更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,171 +1,28 @@
 # AGENTS.md
 
+この文書は、Codex などの LLM エージェントが `tsumugai` を開発するときに参照する行動指針です。
+
+tsumugai の開発方針・責務分離・コード設計の制約・品質ゲートなどの正本は `CLAUDE.md` です。AGENTS.md との内容の重複によるドキュメント間の食い違いを避けるため、本ドキュメントでは共通方針を `CLAUDE.md` への参照に寄せ、Codex 固有の運用（TODO 管理）のみをここに記載します。
+
+作業を始める前に、必ず `CLAUDE.md` を読んでください。特に次の節は毎回の作業に直結します。
+
+- 最優先方針
+- 現在の責務分離（`parse` / `check` / `trace` / `routes` / `fmt` / `report` の構成）
+- コード設計の制約
+- 変更時に必要なレビュー材料
+- Diagnostic 方針
+- CLI / JSON / ログ方針
+- テストと品質ゲート
+- ドキュメント更新
+- 最終報告の方針
+
 > **注記（2026-07-08）**
-> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。以下の Rust 向け記述は、引き続き `src/` 以下の現行実装にそのまま適用されます。`compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加済みで、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できます。
-
-この文書は、Codex などの LLM エージェントが `tsumugai` を開発するときに必ず参照する行動指針です。
-
-tsumugai の主要ユーザーは、Rust やコード読解に詳しいとは限りません。それでも仕様・挙動・出力に対するレビューは実施したい、という前提で開発します。
-
-## 最優先方針
-
-tsumugai では、テクニカルな設計美よりも次を優先します。
-
-- デバッグしやすいこと
-- レビューしやすいこと
-- LLM に原因分析を依頼しやすいこと
-- 入力 Markdown と出力結果の対応が追跡できること
-- コードを読まなくても挙動を確認できること
-
-レビューの単位は Rust コードだけではありません。入力 Markdown、出力 Event、Diagnostic、Trace、DryRunReport、Golden JSON、CLI 出力、テスト結果もレビュー対象です。
-
-## 現在の責務分離
-
-現行の主経路は次の通りです。
-
-```text
-Markdown
-  -> parser::parse
-  -> Ast
-  -> runtime::compile
-  -> IR Program
-  -> runtime::step
-  -> Output { events, waiting_for }
-```
-
-主要モジュール:
-
-- `parser`: Markdown DSL を AST に変換する
-- `analyzer`: AST を静的検証する
-- `runtime`: AST を IR にコンパイルし、State/Input から Output を返す
-- `player`: CUI の参照実装
-- `types`: AST / State などの基本型
-
-runtime は Markdown を直接読みません。parser は実行状態を持ちません。表示、音声再生、UI、アセットロードは core の責務ではありません。
-
-## コード設計の制約
-
-LLM と人間が追跡しやすい Rust を優先します。
-
-優先するもの:
-
-- enum / struct / 関数中心の単純な設計
-- 明示的な `State`
-- 入出力が分かる純粋関数に近い形
-- 小さな責務分離
-- 具体的な型名と分かりやすいモジュール名
-- 失敗時に原因が分かるエラーと Diagnostic
-
-避けるもの:
-
-- 不要な trait 階層
-- generic の乱用
-- macro の多用
-- core logic への早すぎる async 導入
-- 複雑な DI
-- 挙動が追いにくい抽象化
-- コードを読まないと仕様が分からない変更
-
-抽象化は、実際の重複や複雑さを減らす場合だけ導入します。
-
-## 変更時に必要なレビュー材料
-
-挙動を変える変更では、可能な限り次のいずれかを追加・更新します。
-
-- 入力 Markdown 例
-- 出力 Event 例
-- Diagnostic 例
-- Trace 例
-- DryRunReport 例
-- Golden JSON
-- CLI 実行例
-- テストケース
-- README / docs の説明
-
-PR や最終報告では、Rust コードを読まなくても何が変わったか分かるように説明します。
+> TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は不採用が確定しました。Rust 向けの設計制約・責務分離は、引き続き `src/` 以下の現行実装にそのまま適用されます。`compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加済みで、arikoi 側の Svelte 製 player が読み込む StoryBundle JSON を出力できます。
 
 ## TODO 管理方針
 
-作業候補は `../claude_code/TODO.md` で管理します。
+作業候補はリポジトリ直下の `TODO.md` で管理します（`../claude_code/TODO.md` ではありません）。
 
-ユーザーは `../claude_code/TODO.md` の `Inbox` に自由にタスクを追加してかまいません。Codex は作業開始時に `../claude_code/TODO.md` を確認し、必要に応じてタスクへ ID を付け、`Backlog` / `Doing` / `Done` / `Dropped` を整理します。
+ユーザーは `TODO.md` の `Inbox` に自由にタスクを追加してかまいません。Codex は作業開始時に `TODO.md` を確認し、必要に応じてタスクへ ID を付け、`Backlog` / `Doing` / `Done` / `Dropped` を整理します。
 
 タスクを完了した場合は、`Done` に移し、完了日、変更内容、確認したコマンドやレビュー材料を簡潔に残してください。タスクを削除せず、対応しない判断をした場合は `Dropped` に理由を残してください。
-
-## Diagnostic 方針
-
-エラーや警告は、最終的に構造化 Diagnostic として扱える形を目指します。
-
-Diagnostic は以下を持つ想定です。
-
-- `rule_id`
-- `severity`
-- `message`
-- `span`
-- `related_spans`
-- `suggestion`
-
-単なる opaque な文字列エラーに閉じ込めないでください。ユーザーや LLM が「どこを、なぜ、どう直すか」を判断できる情報を優先します。
-
-## CLI / JSON / ログ方針
-
-人間向け出力と機械向け JSON 出力を分けます。
-
-将来的な CLI 方針:
-
-```bash
-tsumugai check scenario.md
-tsumugai check scenario.md --json
-
-tsumugai trace scenario.md
-tsumugai trace scenario.md --json
-
-tsumugai dry-run scenario.md
-tsumugai dry-run scenario.md --json
-```
-
-JSON 出力は、CI、Golden テスト、LLM へのデバッグ依頼に使える安定した形を目指します。エラー時も形式が崩れないようにします。
-
-## テストと品質ゲート
-
-変更後は原則として以下を確認します。
-
-```bash
-cargo fmt --check
-cargo clippy --all-targets -- -D warnings
-cargo test
-```
-
-将来的に重視するテスト:
-
-- Golden JSON 比較
-- CLI 出力のスナップショット
-- サンプルシナリオの `check`
-- サンプルシナリオの `dry-run`
-- README サンプルの doctest
-
-テストを削除・弱体化する変更は慎重に扱い、理由を明記してください。
-
-## ドキュメント更新
-
-挙動、API、CLI、設計方針を変えた場合は、README または `docs/` を更新します。
-
-特に参照する文書:
-
-- `docs/CONCEPT.md`: 存在意義と責務境界
-- `docs/ARCHITECTURE.md`: アーキテクチャ
-- `docs/API.md`: Core と Host の契約
-- `docs/DEVELOPMENT_WORKFLOW.md`: 開発・レビュー・CI 方針
-
-ドキュメントと実装がズレると、非Rustユーザーのレビューが困難になります。ズレを見つけたら、小さくても修正してください。
-
-## 最終報告の方針
-
-作業完了時は、次を簡潔に報告します。
-
-- 何を変えたか
-- どのファイルを変えたか
-- どの検証を通したか
-- 未対応や注意点があるか
-
-ユーザーがコードを読まなくても判断できる説明を優先します。


### PR DESCRIPTION
## Summary
- AGENTS.mdに残っていた旧 `parser/analyzer/runtime/player/types` 構成の記述が、CLAUDE.mdの現行説明（`scenario::parse/check/trace/routes/fmt/report`）と食い違っていた問題を解消
- 共通方針（最優先方針・責務分離・設計制約・レビュー材料・Diagnostic方針・CLI/JSON方針・品質ゲート・ドキュメント更新・最終報告方針）はAGENTS.mdでの重複記述をやめ、CLAUDE.mdを正本として参照する形に変更（今後の食い違い再発を防止）
- TODO管理方針のみCodex固有運用として残存。誤ったパス表記（`../claude_code/TODO.md`）を実際の `./TODO.md` に修正

## Test plan
- [x] ドキュメントのみの変更のため、コード上のテストは対象外
- [x] AGENTS.md / CLAUDE.md の内容突き合わせを目視確認

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 開発時に参照するガイドラインが整理され、優先して読むべき項目が明確になりました。
  * タスク管理の参照先が統一され、ToDo の整理・完了記録・対応不要の記録方法が更新されました。
  * 既存の方針説明が見直され、現在の実装やビルド手順に合う形で注記が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->