### PR TITLE
ci: PRサマリコメント投稿をci.ymlに統合する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
+      issues: write
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
@@ -39,13 +41,67 @@ jobs:
           ${{ runner.os }}-cargo-
 
     - name: Format check
+      id: format
       run: cargo fmt --all -- --check
 
     - name: Clippy check
+      id: clippy
       run: cargo clippy --all-targets -- -D warnings
 
     - name: Tests
+      id: test
       run: cargo test
 
     - name: compile smoke test
+      id: compile
       run: cargo run -- compile examples/spring/scenario/spring_001.md --target web --output /tmp/story-bundle.json
+
+    - name: Comment CI summary
+      if: always() && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const marker = "<!-- ci-summary -->";
+          const rows = [
+            ["Format check", "${{ steps.format.outcome }}"],
+            ["Clippy check", "${{ steps.clippy.outcome }}"],
+            ["Tests", "${{ steps.test.outcome }}"],
+            ["compile smoke test", "${{ steps.compile.outcome }}"],
+          ];
+          const label = (outcome) =>
+            outcome === "success" ? "PASS" : outcome === "skipped" ? "SKIPPED" : "FAIL";
+          const table = [
+            "| Check | Result |",
+            "| --- | --- |",
+            ...rows.map(([name, outcome]) => `| ${name} | ${label(outcome)} |`),
+          ].join("\n");
+          const overall = "${{ job.status }}" === "success" ? "PASS" : "FAIL";
+          const body = `${marker}\n## CI Summary\n\nResult: ${overall}\n\n${table}\n`;
+
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner,
+            repo,
+            issue_number,
+            per_page: 100,
+          });
+          const previous = comments.find((comment) =>
+            comment.user.type === "Bot" && comment.body?.includes(marker)
+          );
+
+          if (previous) {
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: previous.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+          }


### PR DESCRIPTION
## Summary
- 作業ツリーに未コミットのまま残っていた `.github/workflows/lightweight-review.yml`（別ワークフロー案）が、既存の `ci.yml` と fmt/clippy/test/compile smoke test を完全に重複実行する内容だった
- 重複CIを避けるため、`lightweight-review.yml` は採用せず、その狙い（PRにチェック結果サマリをコメント投稿する）だけを既存 `ci.yml` に統合した
- 各ステップに `id` を付与し、最終ステップで `actions/github-script` を使って結果テーブルをPRコメントとして投稿・更新する（2回目以降は同一コメントを上書き）

## Test plan
- [x] `python3`/`ruby` でYAML構文を検証
- [ ] 実際のPRでコメントが投稿されることをCI実行結果で確認（このPR自体で確認できます）