### PR TITLE
Refactor checked project loading for execution commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,100 @@
+# TODO
+
+このファイルは、tsumugai の作業候補を人間と Codex が共有するための管理表です。
+
+ユーザーは自由にタスクを追加・編集してかまいません。Codex は作業開始時と完了時にこのファイルを確認し、必要に応じて ID、状態、メモ、完了履歴を整理します。
+
+## 運用ルール
+
+- 新しいタスクは `Inbox` に箇条書きで追加するだけでよい。
+- Codex は `Inbox` のタスクを確認し、必要なら `Backlog` に移して ID を付ける。
+- Codex が作業するタスクは `Doing` に移す。
+- 完了したタスクは `Done` に移し、完了日と確認内容を書く。
+- やらないと決めたタスクは削除せず、`Dropped` に移して理由を書く。
+- コードを読まなくても判断できるように、タスクには可能な範囲で入力例、期待出力、確認方法を書く。
+
+## 状態
+
+- `Inbox`: まだ整理していない思いつき、要望、違和感
+- `Backlog`: 着手可能なタスク
+- `Doing`: 現在 Codex が対応中のタスク
+- `Done`: 完了済みのタスク
+- `Dropped`: 対応しないことを明示したタスク
+
+## ID ルール
+
+Codex が整理するときに、次の形式で ID を付けます。
+
+```text
+T-0001
+T-0002
+T-0003
+```
+
+ID は再利用しません。タスクを分割した場合は、新しい ID を作り、元タスクのメモに分割先を書きます。
+
+## タスクの書き方
+
+最小形:
+
+```markdown
+- [ ] シナリオチェックで未定義ラベルをもっと分かりやすく出したい
+```
+
+整理後:
+
+```markdown
+### T-0001 未定義ラベル Diagnostic の改善
+
+- 状態: Backlog
+- 種別: Diagnostic
+- 目的: Rust を読まなくても、どのラベル参照が壊れているか分かるようにする
+- 期待する確認材料:
+  - 入力 Markdown 例
+  - Diagnostic 例
+  - テストケース
+- メモ:
+  - `rule_id`, `span`, `suggestion` を確認する
+```
+
+完了時:
+
+```markdown
+### T-0001 未定義ラベル Diagnostic の改善
+
+- 状態: Done
+- 完了日: 2026-05-17
+- 確認:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets -- -D warnings`
+  - `cargo test`
+- 変更:
+  - 未定義ラベルの Diagnostic に修正候補を追加
+  - Golden JSON を更新
+```
+
+## Inbox
+
+自由に追記してください。Codex があとで整理します。
+
+- [ ] 
+
+## Backlog
+
+## Doing
+
+## Done
+
+### T-0001 実行系コマンドの事前検査・読み込み処理の共通化
+
+- 状態: Done
+- 完了日: 2026-07-12
+- 確認:
+  - `cargo fmt --check`
+  - `cargo clippy --all-targets -- -D warnings`
+  - `cargo test`
+- 変更:
+  - `trace` / `routes` / `compile` で重複していた check + project load の入口を `load_checked_project` に集約
+  - 各コマンド固有の実行・探索・bundle 生成ロジックは既存モジュールに残し、影響範囲を入口処理に限定
+
+## Dropped

--- a/src/scenario/compile.rs
+++ b/src/scenario/compile.rs
@@ -21,9 +21,8 @@
 //!   このステップ種別は実装しない（narration / dialogue / choice / jump /
 //!   ending の 5 種のみ）。構文が追加された時点で対応する
 
-use super::check::{CheckOptions, CheckResult, check_path};
-use super::diagnostic::Severity;
-use super::project::{LoadedScene, file_level, load_project, resolve_sibling};
+use super::check::CheckResult;
+use super::project::{LoadedScene, load_checked_project, resolve_sibling};
 use super::routes::{RoutesOptions, routes_path};
 use super::{Block, LinkTarget, Scene};
 use serde::Serialize;
@@ -152,49 +151,16 @@ pub enum BundleAsset {
 /// パスが存在しない・ディレクトリ・検査 error の場合も panic や Err にせず、
 /// Diagnostic 入りの [`CompileResult`] を返す（bundle は None になる）。
 pub fn compile_path(path: &Path, options: &CompileOptions) -> CompileResult {
-    if path.is_dir() {
-        let diag = file_level(
-            "io-error",
-            Severity::Error,
-            path,
-            format!(
-                "{} はディレクトリです。compile は開始するシーンファイル（.md）を 1 つ指定してください",
-                path.display()
-            ),
-        );
-        return CompileResult {
-            file: path.to_path_buf(),
-            check: CheckResult {
-                files: Vec::new(),
-                diagnostics: vec![diag],
-            },
-            bundle: None,
-        };
-    }
-
-    let check_options = CheckOptions {
-        check_assets: options.check_assets,
-        ..CheckOptions::default()
+    let mut project = match load_checked_project(path, "compile", options.check_assets) {
+        Ok(project) => project,
+        Err(check) => {
+            return CompileResult {
+                file: path.to_path_buf(),
+                check,
+                bundle: None,
+            };
+        }
     };
-    let mut check = check_path(path, &check_options);
-    if check.has_errors() {
-        return CompileResult {
-            file: path.to_path_buf(),
-            check,
-            bundle: None,
-        };
-    }
-
-    let mut load_diagnostics = Vec::new();
-    let scenes = load_project(vec![path.to_path_buf()], &mut load_diagnostics);
-    check.diagnostics.extend(load_diagnostics);
-    if check.has_errors() || scenes.is_empty() {
-        return CompileResult {
-            file: path.to_path_buf(),
-            check,
-            bundle: None,
-        };
-    }
 
     // check だけでは分からない循環・到達不能を routes の全分岐探索で検出する
     let routes_options = RoutesOptions {
@@ -202,20 +168,20 @@ pub fn compile_path(path: &Path, options: &CompileOptions) -> CompileResult {
         ..RoutesOptions::default()
     };
     if let Some(report) = routes_path(path, &routes_options).report {
-        check.diagnostics.extend(report.diagnostics);
+        project.check.diagnostics.extend(report.diagnostics);
     }
-    if check.has_errors() {
+    if project.check.has_errors() {
         return CompileResult {
             file: path.to_path_buf(),
-            check,
+            check: project.check,
             bundle: None,
         };
     }
 
-    let bundle = build_bundle(&scenes, path);
+    let bundle = build_bundle(&project.scenes, path);
     CompileResult {
         file: path.to_path_buf(),
-        check,
+        check: project.check,
         bundle: Some(bundle),
     }
 }

--- a/src/scenario/project.rs
+++ b/src/scenario/project.rs
@@ -6,6 +6,7 @@
 //! - ファイル: そのファイルとリンクで辿れる閉包
 //! - ファイル参照はシーンファイルからの相対パスのみ（SPEC 2章）
 
+use super::check::{CheckOptions, CheckResult, check_path};
 use super::diagnostic::{Diagnostic, Severity};
 use super::parse::{Parsed, parse_file};
 use super::{Block, LinkTarget, Scene};
@@ -19,6 +20,62 @@ pub(super) struct LoadedScene {
     /// 同一ファイル判定用の正規化パス
     pub(super) canon: PathBuf,
     pub(super) parsed: Parsed,
+}
+
+/// 実行系コマンドが使う、検査済みのプロジェクト。
+///
+/// `trace` / `routes` / `compile` はどれも check と同じ規則で事前検査し、
+/// error があれば本処理を行わない。ここでその入口だけを共有し、各コマンドの
+/// 実行・探索・bundle 生成ロジックはそれぞれのモジュールに残す。
+pub(super) struct CheckedProject {
+    pub(super) check: CheckResult,
+    pub(super) scenes: Vec<LoadedScene>,
+}
+
+/// check と同じ規則で検査したあと、実行系コマンド用にシーン閉包を読み込む。
+///
+/// `check_path` はディレクトリも検査対象にできるが、実行系コマンドは開始する
+/// シーンファイルを 1 つ必要とするため、ディレクトリだけはコマンド名入りの
+/// `io-error` にする。
+pub(super) fn load_checked_project(
+    path: &Path,
+    command: &str,
+    check_assets: bool,
+) -> Result<CheckedProject, CheckResult> {
+    if path.is_dir() {
+        let diag = file_level(
+            "io-error",
+            Severity::Error,
+            path,
+            format!(
+                "{} はディレクトリです。{} は開始するシーンファイル（.md）を 1 つ指定してください",
+                path.display(),
+                command
+            ),
+        );
+        return Err(CheckResult {
+            files: Vec::new(),
+            diagnostics: vec![diag],
+        });
+    }
+
+    let check_options = CheckOptions {
+        check_assets,
+        ..CheckOptions::default()
+    };
+    let mut check = check_path(path, &check_options);
+    if check.has_errors() {
+        return Err(check);
+    }
+
+    let mut load_diagnostics = Vec::new();
+    let scenes = load_project(vec![path.to_path_buf()], &mut load_diagnostics);
+    check.diagnostics.extend(load_diagnostics);
+    if check.has_errors() || scenes.is_empty() {
+        return Err(check);
+    }
+
+    Ok(CheckedProject { check, scenes })
 }
 
 /// ディレクトリ配下の `.md` を再帰的に集める（名前順）。

--- a/src/scenario/routes.rs
+++ b/src/scenario/routes.rs
@@ -12,10 +12,10 @@
 //!   ending / シーン・深度超過・経路数上限による打ち切り）は warning
 
 use super::Block;
-use super::check::{CheckOptions, CheckResult, check_path};
+use super::check::CheckResult;
 use super::diagnostic::{Diagnostic, Severity};
 use super::exec::{Cursor, format_choices, goto, segment_blocks};
-use super::project::{LoadedScene, file_level, load_project};
+use super::project::{LoadedScene, file_level, load_checked_project};
 use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -117,54 +117,21 @@ impl RoutesResult {
 /// パスが存在しない・ディレクトリ・検査 error の場合も panic や Err にせず、
 /// Diagnostic 入りの [`RoutesResult`] を返す（report は None になる）。
 pub fn routes_path(path: &Path, options: &RoutesOptions) -> RoutesResult {
-    if path.is_dir() {
-        let diag = file_level(
-            "io-error",
-            Severity::Error,
-            path,
-            format!(
-                "{} はディレクトリです。routes は開始するシーンファイル（.md）を 1 つ指定してください",
-                path.display()
-            ),
-        );
-        return RoutesResult {
-            file: path.to_path_buf(),
-            check: CheckResult {
-                files: Vec::new(),
-                diagnostics: vec![diag],
-            },
-            report: None,
-        };
-    }
-
-    let check_options = CheckOptions {
-        check_assets: options.check_assets,
-        ..CheckOptions::default()
+    let project = match load_checked_project(path, "routes", options.check_assets) {
+        Ok(project) => project,
+        Err(check) => {
+            return RoutesResult {
+                file: path.to_path_buf(),
+                check,
+                report: None,
+            };
+        }
     };
-    let mut check = check_path(path, &check_options);
-    if check.has_errors() {
-        return RoutesResult {
-            file: path.to_path_buf(),
-            check,
-            report: None,
-        };
-    }
 
-    let mut load_diagnostics = Vec::new();
-    let scenes = load_project(vec![path.to_path_buf()], &mut load_diagnostics);
-    check.diagnostics.extend(load_diagnostics);
-    if check.has_errors() || scenes.is_empty() {
-        return RoutesResult {
-            file: path.to_path_buf(),
-            check,
-            report: None,
-        };
-    }
-
-    let report = explore(&scenes, path, options);
+    let report = explore(&project.scenes, path, options);
     RoutesResult {
         file: path.to_path_buf(),
-        check,
+        check: project.check,
         report: Some(report),
     }
 }

--- a/src/scenario/trace.rs
+++ b/src/scenario/trace.rs
@@ -10,10 +10,9 @@
 //!   [`TraceResult`] に含め、JSON 出力の形式を崩さない
 
 use super::Block;
-use super::check::{CheckOptions, CheckResult, check_path};
-use super::diagnostic::Severity;
+use super::check::CheckResult;
 use super::exec::{Cursor, GotoResult, goto, segment_blocks, target_string};
-use super::project::{LoadedScene, file_level, load_project};
+use super::project::{LoadedScene, load_checked_project};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -150,57 +149,21 @@ impl TraceResult {
 /// パスが存在しない・ディレクトリ・検査 error の場合も panic や Err にせず、
 /// Diagnostic 入りの [`TraceResult`] を返す（trace は None になる）。
 pub fn trace_path(path: &Path, options: &TraceOptions) -> TraceResult {
-    if path.is_dir() {
-        let diag = file_level(
-            "io-error",
-            Severity::Error,
-            path,
-            format!(
-                "{} はディレクトリです。trace は開始するシーンファイル（.md）を 1 つ指定してください",
-                path.display()
-            ),
-        );
-        return TraceResult {
-            file: path.to_path_buf(),
-            check: CheckResult {
-                files: Vec::new(),
-                diagnostics: vec![diag],
-            },
-            trace: None,
-        };
-    }
-
-    // 実行前に check と同じ検査を行う（SPEC 6.1: どのコマンドから入っても同じ指摘）
-    let check_options = CheckOptions {
-        check_assets: options.check_assets,
-        ..CheckOptions::default()
+    let project = match load_checked_project(path, "trace", options.check_assets) {
+        Ok(project) => project,
+        Err(check) => {
+            return TraceResult {
+                file: path.to_path_buf(),
+                check,
+                trace: None,
+            };
+        }
     };
-    let mut check = check_path(path, &check_options);
-    if check.has_errors() {
-        return TraceResult {
-            file: path.to_path_buf(),
-            check,
-            trace: None,
-        };
-    }
 
-    // check と同じ規則でシーン閉包を読み込む。check 直後に消える等の
-    // 入出力エラーはここでも Diagnostic にする
-    let mut load_diagnostics = Vec::new();
-    let scenes = load_project(vec![path.to_path_buf()], &mut load_diagnostics);
-    check.diagnostics.extend(load_diagnostics);
-    if check.has_errors() || scenes.is_empty() {
-        return TraceResult {
-            file: path.to_path_buf(),
-            check,
-            trace: None,
-        };
-    }
-
-    let trace = run(&scenes, options);
+    let trace = run(&project.scenes, options);
     TraceResult {
         file: path.to_path_buf(),
-        check,
+        check: project.check,
         trace: Some(trace),
     }
 }


### PR DESCRIPTION
## Summary
- Add `load_checked_project` to share the check + project loading entrypoint used by execution commands
- Simplify `trace`, `routes`, and `compile` so each keeps its command-specific logic while using the shared preflight path
- Record the completed refactoring task in `TODO.md`

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Note: Cargo emitted hard-link fallback warnings for the incremental cache on the external drive, but all commands completed successfully.