### PR TITLE
docs: READMEにアーカイブ告知を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # tsumugai
 
+> **このリポジトリはアーカイブされています。（2026-07-15）**
+>
+> tsumugai は、作者向けの独自シナリオ形式と、それを実行・検証する独自の基盤（静的検査・経路検証 CLI）を提供することを目的としていました。
+>
+> 現在、この目的は、音声で語られたシナリオをティラノスクリプトへ変換し、既存のティラノスクリプトを実行基盤として利用する [voice-to-tyrano](https://github.com/kosuke-fujisawa/voice-to-tyrano) によって、より単純に実現できると判断しています。
+>
+> シナリオ構造の考え方、分岐・到達可能性の検査観点、CI による検証方針などの再利用可能な設計知識は voice-to-tyrano へ移行しました。経緯は voice-to-tyrano の [docs/migration-from-tsumugai.md](https://github.com/kosuke-fujisawa/voice-to-tyrano/blob/main/docs/migration-from-tsumugai.md) を参照してください。
+
+---
+
 > **注記（2026-07-08）**
 > TypeScript / Svelte / Vite への全面移行（[epic #99](https://github.com/kosuke-fujisawa/tsumugai/issues/99)）は検討の結果、不採用が確定しました。tsumugai は、以下に説明する通り Rust 製の静的検査・経路検証 CLI として維持します。`compile --target web` コマンド（[#128](https://github.com/kosuke-fujisawa/tsumugai/issues/128)）を追加済みで、外部の Web フロントエンド（arikoi の Svelte 製 player 等）向けに StoryBundle JSON を出力できます。連携は npm 依存ではなく CLI サブプロセス経由で行います。
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > **このリポジトリはアーカイブされています。（2026-07-15）**
 >
-> tsumugai は、作者向けの独自シナリオ形式と、それを実行・検証する独自の基盤（静的検査・経路検証 CLI）を提供することを目的としていました。
+> tsumugai は、作者向けの独自シナリオ形式と、それを実行・検証する独自ランタイム基盤（静的検査・経路検証 CLI）を提供することを目的としていました。
 >
-> 現在、この目的は、音声で語られたシナリオをティラノスクリプトへ変換し、既存のティラノスクリプトを実行基盤として利用する [voice-to-tyrano](https://github.com/kosuke-fujisawa/voice-to-tyrano) によって、より単純に実現できると判断しています。
+> 現在、この目的は、自然言語で記述されたシナリオをティラノスクリプトへ変換し、既存のティラノスクリプトを実行基盤として利用する [scenario-to-tyrano](https://github.com/kosuke-fujisawa/scenario-to-tyrano) によって、より単純に実現できると判断しています。
 >
-> シナリオ構造の考え方、分岐・到達可能性の検査観点、CI による検証方針などの再利用可能な設計知識は voice-to-tyrano へ移行しました。経緯は voice-to-tyrano の [docs/migration-from-tsumugai.md](https://github.com/kosuke-fujisawa/voice-to-tyrano/blob/main/docs/migration-from-tsumugai.md) を参照してください。
+> シナリオ構造の考え方、分岐・到達可能性の検査観点、CI による検証方針などの再利用可能な設計知識は scenario-to-tyrano へ移行しました。経緯は scenario-to-tyrano の [docs/migration-from-tsumugai.md](https://github.com/kosuke-fujisawa/scenario-to-tyrano/blob/main/docs/migration-from-tsumugai.md) を参照してください。
 
 ---
 


### PR DESCRIPTION
## 変更概要

README冒頭に、このリポジトリをアーカイブする旨の告知を追加します。

- tsumugaiの目的（独自シナリオ形式と独自ランタイム基盤の提供）は、自然言語で記述されたシナリオをティラノスクリプトへ変換する [scenario-to-tyrano](https://github.com/kosuke-fujisawa/scenario-to-tyrano) によって、より単純に実現できると判断
- シナリオ構造・分岐検査・CI検証などの再利用可能な設計知識は scenario-to-tyrano の [docs/migration-from-tsumugai.md](https://github.com/kosuke-fujisawa/scenario-to-tyrano/blob/main/docs/migration-from-tsumugai.md) へ移行済み
- tsumugaiは失敗作としてではなく、問題設定の変化によって役割を終えたものとして記録

（2コミット目: 移行先プロジェクトが `voice-to-tyrano` から `scenario-to-tyrano` へ改名されたため、告知内の名称・リンク・趣旨を更新）

## 影響範囲

README.mdの冒頭への追記のみ。コード・CI・仕様への変更はありません。

このPRのマージ後、GitHub上のArchive操作は人間が行う想定です。

@coderabbitai レビューをお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)